### PR TITLE
Adding signals as new tenancy model

### DIFF
--- a/eox_tenant/backends/database.py
+++ b/eox_tenant/backends/database.py
@@ -47,6 +47,17 @@ class EdunextCompatibleDatabaseMicrositeBackend(BaseMicrositeBackend):
         for microsite in candidates:
             yield microsite
 
+    def get_config_by_domain(self, domain):
+        """
+        Return the configuration and key available for a given domain without applying it
+        to the local thread
+        """
+        microsite = self.microsite_manager.get_microsite_for_domain(domain)
+        if microsite:
+            return microsite.values, microsite.key
+        else:
+            return {}, None
+
     def set_config_by_domain(self, domain):
         """
         For a given request domain, find a match in our microsite configuration

--- a/eox_tenant/edxapp_wrapper/backends/microsite_configuration_test_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/microsite_configuration_test_v1.py
@@ -1,0 +1,35 @@
+""" Backend abstraction. """
+
+from eox_tenant.backends.base import AbstractBaseMicrositeBackend
+
+
+def get_base_microsite_backend():
+    """ Backend to get BaseMicrositeBackend. """
+    try:
+        from microsite_configuration.backends.base import BaseMicrositeBackend as InterfaceConnectionBackend
+    except ImportError:
+        InterfaceConnectionBackend = AbstractBaseMicrositeBackend
+    return InterfaceConnectionBackend
+
+def get_base_microsite_template_backend():
+    """ Backend to get BaseMicrositeTemplateBackend. """
+    try:
+        from microsite_configuration.backends.base import BaseMicrositeTemplateBackend
+    except ImportError:
+        from eox_tenant.backends.base import BaseMicrositeTemplateBackend
+    return BaseMicrositeTemplateBackend
+
+def get_microsite():
+    """ Backend to get microsite. """
+    from microsite_configuration import microsite # pylint: disable=import-error
+    return microsite
+
+def get_microsite_get_value(*args, **kwargs):
+    """ Backend to get get_value. """
+    from microsite_configuration.microsite import get_value
+    return get_value(*args, **kwargs)
+
+def get_is_request_in_microsite():
+    """ Backend to get is_request_in_microsite. """
+    from microsite_configuration.microsite import is_request_in_microsite
+    return is_request_in_microsite

--- a/eox_tenant/edxapp_wrapper/backends/microsite_configuration_test_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/microsite_configuration_test_v1.py
@@ -11,6 +11,7 @@ def get_base_microsite_backend():
         InterfaceConnectionBackend = AbstractBaseMicrositeBackend
     return InterfaceConnectionBackend
 
+
 def get_base_microsite_template_backend():
     """ Backend to get BaseMicrositeTemplateBackend. """
     try:
@@ -19,17 +20,20 @@ def get_base_microsite_template_backend():
         from eox_tenant.backends.base import BaseMicrositeTemplateBackend
     return BaseMicrositeTemplateBackend
 
+
 def get_microsite():
     """ Backend to get microsite. """
-    from microsite_configuration import microsite # pylint: disable=import-error
+    from microsite_configuration import microsite  # pylint: disable=import-error
     return microsite
+
 
 def get_microsite_get_value(*args, **kwargs):
     """ Backend to get get_value. """
-    from microsite_configuration.microsite import get_value
+    from microsite_configuration.microsite import get_value  # pylint: disable=import-error
     return get_value(*args, **kwargs)
+
 
 def get_is_request_in_microsite():
     """ Backend to get is_request_in_microsite. """
-    from microsite_configuration.microsite import is_request_in_microsite
+    from microsite_configuration.microsite import is_request_in_microsite  # pylint: disable=import-error
     return is_request_in_microsite

--- a/eox_tenant/models.py
+++ b/eox_tenant/models.py
@@ -33,6 +33,7 @@ class Microsite(models.Model):
         """
         # Note to ops: The table already exists under a different name due to the migration from EOE.
         db_table = 'ednx_microsites_microsites'
+        app_label = "eox_tenant"
 
     def __unicode__(self):
         return self.key

--- a/eox_tenant/settings/aws.py
+++ b/eox_tenant/settings/aws.py
@@ -19,3 +19,8 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'MICROSITE_TEMPLATE_BACKEND',
         settings.MICROSITE_TEMPLATE_BACKEND
     )
+
+    settings.EOX_MAX_CONFIG_OVERRIDE_SECONDS = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_MAX_CONFIG_OVERRIDE_SECONDS',
+        settings.EOX_MAX_CONFIG_OVERRIDE_SECONDS
+    )

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -39,3 +39,5 @@ def plugin_settings(settings):
     settings.MICROSITE_TEMPLATE_BACKEND = \
         'eox_tenant.backends.filebased.EdunextCompatibleFilebasedMicrositeTemplateBackend'
     settings.MICROSITE_CONFIGURATION_BACKEND = 'eox_tenant.edxapp_wrapper.backends.microsite_configuration_h_v1'
+
+    settings.EOX_MAX_CONFIG_OVERRIDE_SECONDS = 300

--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -13,3 +13,9 @@ class SettingsClass(object):
 SETTINGS = SettingsClass()
 plugin_settings(SETTINGS)
 vars().update(SETTINGS.__dict__)
+
+MICROSITE_CONFIGURATION_BACKEND = 'eox_tenant.edxapp_wrapper.backends.microsite_configuration_test_v1'
+
+TEST_DICT_OVERRIDE_TEST = {
+    "key1": "Some Value"
+}

--- a/eox_tenant/signals.py
+++ b/eox_tenant/signals.py
@@ -18,11 +18,13 @@ LOGGING['loggers']['eox_tenant'] = {
 }
 
 """
+from __future__ import print_function, unicode_literals
+
 import logging
 import os
-
 from datetime import datetime
 
+import six
 from django.conf import settings as base_settings
 
 from eox_tenant.backends.database import EdunextCompatibleDatabaseMicrositeBackend
@@ -49,7 +51,7 @@ def _update_settings(domain):
     base_settings.EDNX_TENANT_SETUP_TIME = datetime.now()
 
     LOG.debug("PID: %s CONFIGURING THE SETTINGS OBJECT | %s", os.getpid(), tenant_key)
-    for key, value in config.iteritems():
+    for key, value in six.iteritems(config):
         if isinstance(value, dict):
             merged = getattr(base_settings, key, {}).copy()
             merged.update(value)
@@ -86,7 +88,8 @@ def _analyze_current_settings(domain):
             LOG.debug("SETTINGS WILL RESET | Reason: domain and current settings do not match")
     except AttributeError:
         must_reset = True
-        LOG.debug("SETTINGS WILL RESET | Reason: we could not find EDNX_TENANT_DOMAIN in the current settings object. PID: %s", os.getpid())
+        LOG.debug("SETTINGS WILL RESET | Reason: we could not find "
+                  "EDNX_TENANT_DOMAIN in the current settings object. PID: %s", os.getpid())
 
     return must_reset, can_keep
 
@@ -95,7 +98,7 @@ def _perform_reset():
     """
     Defers to the original django.conf.settings to a new initialization
     """
-    base_settings._setup()
+    base_settings._setup()  # pylint: disable=protected-access
     LOG.debug("Reset on the settings object for PID: %s", os.getpid())
 
 
@@ -125,7 +128,7 @@ def _get_tenant_config(domain):
     return backend.get_config_by_domain(domain)
 
 
-def start_tenant(sender, environ, **kwargs):
+def start_tenant(sender, environ, **kwargs):  # pylint: disable=unused-argument
     """
     This function runs every time a request is started.
     It will analyze the current settings object, the domain from the incoming
@@ -164,7 +167,7 @@ def start_tenant(sender, environ, **kwargs):
     _update_settings(domain)
 
 
-def finish_tenant(sender, **kwargs):
+def finish_tenant(sender, **kwargs):  # pylint: disable=unused-argument
     """
     This function should terminate the tenant specific changes
 
@@ -175,7 +178,7 @@ def finish_tenant(sender, **kwargs):
     pass
 
 
-def clear_tenant(sender, request, **kwargs):
+def clear_tenant(sender, request, **kwargs):  # pylint: disable=unused-argument
     """
     This function should terminate the tenant specific changes when the request fails unexpectedly
 

--- a/eox_tenant/signals.py
+++ b/eox_tenant/signals.py
@@ -1,0 +1,180 @@
+# -*- coding: utf-8 -*-
+"""
+Eox Tenant Signals
+==================
+This module makes it possible to override the settings object for a tenant.
+
+How to debug in devstack
+========================
+
+Add the following lines to the lms.envs.devstack_docker module
+
+LOGGING['handlers']['console']['level'] = 'DEBUG'
+LOGGING['loggers']['']['level'] = 'INFO'
+LOGGING['loggers']['eox_tenant'] = {
+    'handlers': ['console'],
+    'propagate': False,
+    'level': 'DEBUG'
+}
+
+"""
+import logging
+import os
+
+from datetime import datetime
+
+from celery.signals import after_task_publish, before_task_publish
+from django.conf import settings as base_settings
+from django.core import signals
+
+from eox_tenant.backends.database import EdunextCompatibleDatabaseMicrositeBackend
+
+
+LOG = logging.getLogger(__name__)
+
+# Read at the beginning so this can not be modified by the tenant configs
+EOX_MAX_CONFIG_OVERRIDE_SECONDS = getattr(base_settings, "EOX_MAX_CONFIG_OVERRIDE_SECONDS", 300)
+
+
+def _update_settings(domain):
+    """
+    Perform the override procedure on the settings object
+    """
+    config, tenant_key = _get_tenant_config(domain)
+
+    if not config.get("EDNX_USE_SIGNAL"):
+        LOG.info("Site %s, does not use Signals", domain)
+        return
+
+    base_settings.__setattr__("EDNX_TENANT_KEY", tenant_key)
+    base_settings.__setattr__("EDNX_TENANT_DOMAIN", domain)
+    base_settings.__setattr__("EDNX_TENANT_SETUP_TIME", datetime.now())
+
+    LOG.debug("PID: %s CONFIGURING THE SETTINGS OBJECT | %s", os.getpid(), tenant_key)
+    for key, value in config.iteritems():
+        if isinstance(value, dict):
+            merged = base_settings.__getattr__(key).copy()
+            merged.update(value)
+            base_settings.__setattr__(key, merged)
+            continue
+        base_settings.__setattr__(key, value)
+
+
+def _analyze_current_settings(domain):
+    """
+    The logic in here will determine if the current settings object has already been
+    updated and if it has the matching overrides for the current request
+
+    By default should anything go wrong, the function will always return that
+    the settings object MUST be reset, and can NOT be kept
+    """
+    must_reset = True
+    can_keep = False
+
+    has_tenant_key = False
+    try:
+        current_key = base_settings.__getattr__("EDNX_TENANT_KEY")
+        has_tenant_key = True
+        LOG.debug("PID: %s | The current_key: %s | the current domain: %s", os.getpid(), current_key, domain)
+    except AttributeError:
+        must_reset = False
+        LOG.debug("PID: %s | No TENANT CONFIGURED SO FAR", os.getpid())
+
+    try:
+        if has_tenant_key and base_settings.EDNX_TENANT_DOMAIN == domain:
+            must_reset = False
+            can_keep = True
+        else:
+            if must_reset:
+                LOG.debug("SETTINGS WILL RESET | Reason: domain and current settings do not match")
+    except AttributeError:
+        must_reset = True
+        LOG.debug("SETTINGS WILL RESET | Reason: we could not find EDNX_TENANT_DOMAIN in the current settings object. PID: %s", os.getpid())
+
+    return must_reset, can_keep
+
+
+def _ttl_reached():
+    """
+    Determines if the current settings object has been configured too long ago
+    as defined in the MAX_CONFIG_OVERRIDE_SECONDS settings variable
+    """
+    try:
+        if (datetime.now() - base_settings.EDNX_TENANT_SETUP_TIME).seconds > EOX_MAX_CONFIG_OVERRIDE_SECONDS:
+            LOG.debug("SETTINGS WILL RESET | Reason: maximum time for this config override was reached")
+            return True
+    except AttributeError:
+        pass
+
+    return False
+
+
+def _get_tenant_config(domain):
+    """
+    Reach for the configuration for a given domain
+
+    Using the model directly introduces a circular dependency.
+    That is why we go through the MicrositeBacked implementation.
+    """
+    backend = EdunextCompatibleDatabaseMicrositeBackend()
+    return backend.get_config_by_domain(domain)
+
+
+def start_tenant(sender, environ, **kwargs):
+    """
+    This function runs every time a request is started.
+    It will analyze the current settings object, the domain from the incoming
+    request and the configuration stored in the tenants for this domain.
+
+    Based on this input it will modify the settings objects in one of three possible ways:
+
+    - reset the object to remove any previous modification
+    - override the object with the settings stored for the tenant
+    - reset the object and then override with a new tenant
+
+    Signal: django.core.signals.request_started
+    """
+
+    if base_settings.SERVICE_VARIANT == "cms":
+        LOG.debug("Studio does not support eox_tenant signals yet")
+        return
+
+    domain = environ.get("HTTP_HOST").split(':')[0]
+
+    # Find what we need to do about the current setting and the incoming request.domain
+    must_reset, can_keep = _analyze_current_settings(domain)
+
+    # Reset minimum once every so often
+    must_reset = _ttl_reached() or must_reset
+
+    # Perform the reset
+    if must_reset:
+        base_settings._setup()
+        can_keep = False
+        LOG.debug("Reset on the settings object for PID: %s", os.getpid())
+
+    if can_keep:
+        return
+
+    # Do the update
+    _update_settings(domain)
+
+
+def finish_tenant(sender, **kwargs):
+    """
+    This function should terminate the tenant specific changes
+
+    Signal: django.core.signals.request_finished
+
+    Since the signal is not very reliable nothing is being done in it
+    """
+    pass
+
+
+def clear_tenant(sender, request, **kwargs):
+    """
+    This function should terminate the tenant specific changes when the request fails unexpectedly
+
+    Signal: django.core.signals.got_request_exception
+    """
+    pass

--- a/eox_tenant/signals.py
+++ b/eox_tenant/signals.py
@@ -24,7 +24,6 @@ import os
 from datetime import datetime
 
 from django.conf import settings as base_settings
-from django.core import signals
 
 from eox_tenant.backends.database import EdunextCompatibleDatabaseMicrositeBackend
 

--- a/eox_tenant/test/test_signals.py
+++ b/eox_tenant/test/test_signals.py
@@ -2,10 +2,11 @@
 """
 Tests for the signals module
 """
+from __future__ import print_function, unicode_literals
+
 from datetime import datetime, timedelta
 
 from django.test import TestCase
-from django.core.exceptions import ValidationError
 from mock import MagicMock, patch
 
 from eox_tenant.signals import (
@@ -71,6 +72,8 @@ class StartTenantSignalTest(TestCase):
     @patch('eox_tenant.signals._update_settings')
     def test_can_not_keep_because_analysis(self, _update_mock, _reset_mock, _analyze_mock):
         """
+        Unless the domain and current config match, the analysis will always
+        determine we can not keep the current settings
         """
         environ = MagicMock()
         environ.get.return_value = 'tenant.com'
@@ -88,6 +91,8 @@ class StartTenantSignalTest(TestCase):
     @patch('eox_tenant.signals._update_settings')
     def test_can_keep(self, _update_mock, _reset_mock, _analyze_mock):
         """
+        When the domain and current config match, the analysis will
+        determine that we can keep the current settings
         """
         environ = MagicMock()
         environ.get.return_value = 'tenant.com'
@@ -153,7 +158,7 @@ class SettingsOverridesTest(TestCase):
         Must reset after every test
         """
         from django.conf import settings
-        settings._setup()
+        settings._setup()  # pylint: disable=protected-access
 
     @patch('eox_tenant.signals._get_tenant_config')
     def test_udpate_settings_mark(self, _get_config_mock):
@@ -168,7 +173,7 @@ class SettingsOverridesTest(TestCase):
         _update_settings("tenant.com")
 
         with self.assertRaises(AttributeError):
-            settings.EDNX_TENANT_KEY
+            settings.EDNX_TENANT_KEY  # pylint: disable=pointless-statement
 
     @patch('eox_tenant.signals._get_tenant_config')
     def test_udpate_settings(self, _get_config_mock):
@@ -183,7 +188,7 @@ class SettingsOverridesTest(TestCase):
 
         _update_settings("tenant.com")
 
-        settings.EDNX_TENANT_KEY
+        settings.EDNX_TENANT_KEY  # pylint: disable=pointless-statement
 
     @patch('eox_tenant.signals._get_tenant_config')
     def test_udpate_settings_with_property(self, _get_config_mock):
@@ -199,7 +204,7 @@ class SettingsOverridesTest(TestCase):
 
         _update_settings("tenant.com")
 
-        self.assertEquals(settings.TEST_PROPERTY, "My value")
+        self.assertEqual(settings.TEST_PROPERTY, "My value")
 
     @patch('eox_tenant.signals._get_tenant_config')
     def test_udpate_settings_with_dict(self, _get_config_mock):
@@ -217,7 +222,7 @@ class SettingsOverridesTest(TestCase):
 
         _update_settings("tenant.com")
 
-        self.assertEquals(settings.TEST_DICT.get("TEST_PROPERTY"), "My value")
+        self.assertEqual(settings.TEST_DICT.get("TEST_PROPERTY"), "My value")
 
     @patch('eox_tenant.signals._get_tenant_config')
     def test_udpate_settings_with_existing_dict(self, _get_config_mock):
@@ -235,5 +240,5 @@ class SettingsOverridesTest(TestCase):
 
         _update_settings("tenant.com")
 
-        self.assertEquals(settings.TEST_DICT_OVERRIDE_TEST.get("key1"), "Some Value")
-        self.assertEquals(settings.TEST_DICT_OVERRIDE_TEST.get("key2"), "My value")
+        self.assertEqual(settings.TEST_DICT_OVERRIDE_TEST.get("key1"), "Some Value")
+        self.assertEqual(settings.TEST_DICT_OVERRIDE_TEST.get("key2"), "My value")

--- a/eox_tenant/test/test_signals.py
+++ b/eox_tenant/test/test_signals.py
@@ -112,7 +112,6 @@ class StartTenantSignalTest(TestCase):
 
         self.assertFalse(_ttl_reached())
 
-
     def test__analyze_current_settings_no_domain(self):
         """
         The settings for a blank incoming request can not be kept and must not be restarted
@@ -219,7 +218,6 @@ class SettingsOverridesTest(TestCase):
         _update_settings("tenant.com")
 
         self.assertEquals(settings.TEST_DICT.get("TEST_PROPERTY"), "My value")
-
 
     @patch('eox_tenant.signals._get_tenant_config')
     def test_udpate_settings_with_existing_dict(self, _get_config_mock):

--- a/eox_tenant/test/test_signals.py
+++ b/eox_tenant/test/test_signals.py
@@ -1,0 +1,241 @@
+#!/usr/bin/python
+"""
+Tests for the signals module
+"""
+from datetime import datetime, timedelta
+
+from django.test import TestCase
+from django.core.exceptions import ValidationError
+from mock import MagicMock, patch
+
+from eox_tenant.signals import (
+    start_tenant,
+    _ttl_reached,
+    _update_settings,
+    _analyze_current_settings,
+)
+
+
+class StartTenantSignalTest(TestCase):
+    """
+    Testing the signal sent at the start of every request
+    """
+
+    def test_nothing_changes_studio(self):
+        """
+        The cms should return inmediatly, not even try to get the domain
+        """
+        environ = MagicMock()
+        with self.settings(SERVICE_VARIANT='cms'):
+            start_tenant(None, environ)
+            environ.get.assert_not_called()
+
+    @patch('eox_tenant.signals._analyze_current_settings')
+    @patch('eox_tenant.signals._perform_reset')
+    @patch('eox_tenant.signals._update_settings')
+    def test_must_reset_because_domain(self, _, _reset_mock, _analyze_mock):
+        """
+        If the analysis determines that a reset is required. It has to be done
+        """
+        environ = MagicMock()
+        environ.get.return_value = 'tenant.com'
+
+        _analyze_mock.return_value = (True, None)
+
+        with self.settings(SERVICE_VARIANT='lms'):
+            start_tenant(None, environ)
+
+        _reset_mock.assert_called()
+
+    @patch('eox_tenant.signals._analyze_current_settings')
+    @patch('eox_tenant.signals._perform_reset')
+    @patch('eox_tenant.signals._update_settings')
+    @patch('eox_tenant.signals._ttl_reached')
+    def test_must_reset_ttl(self, _ttl_mock, _, _reset_mock, _analyze_mock):
+        """
+        If the ttl determines that a reset is required. It has to be done
+        """
+        environ = MagicMock()
+        environ.get.return_value = 'tenant.com'
+
+        _analyze_mock.return_value = (False, None)
+        _ttl_mock.return_value = True
+
+        with self.settings(SERVICE_VARIANT='lms'):
+            start_tenant(None, environ)
+
+        _reset_mock.assert_called()
+
+    @patch('eox_tenant.signals._analyze_current_settings')
+    @patch('eox_tenant.signals._perform_reset')
+    @patch('eox_tenant.signals._update_settings')
+    def test_can_not_keep_because_analysis(self, _update_mock, _reset_mock, _analyze_mock):
+        """
+        """
+        environ = MagicMock()
+        environ.get.return_value = 'tenant.com'
+
+        _analyze_mock.return_value = (False, False)
+
+        with self.settings(SERVICE_VARIANT='lms'):
+            start_tenant(None, environ)
+
+        _reset_mock.assert_not_called()
+        _update_mock.assert_called()
+
+    @patch('eox_tenant.signals._analyze_current_settings')
+    @patch('eox_tenant.signals._perform_reset')
+    @patch('eox_tenant.signals._update_settings')
+    def test_can_keep(self, _update_mock, _reset_mock, _analyze_mock):
+        """
+        """
+        environ = MagicMock()
+        environ.get.return_value = 'tenant.com'
+
+        _analyze_mock.return_value = (False, True)
+
+        with self.settings(SERVICE_VARIANT='lms'):
+            start_tenant(None, environ)
+
+        _reset_mock.assert_not_called()
+        _update_mock.assert_not_called()
+
+    def test__ttl_reached(self):
+        """
+        By default we set 5 minutes as the max time a particular settings override can live
+        """
+        with self.settings(EDNX_TENANT_SETUP_TIME=(datetime.now() - timedelta(minutes=6))):
+            self.assertTrue(_ttl_reached())
+
+        with self.settings(EDNX_TENANT_SETUP_TIME=(datetime.now() - timedelta(minutes=4))):
+            self.assertFalse(_ttl_reached())
+
+        self.assertFalse(_ttl_reached())
+
+
+    def test__analyze_current_settings_no_domain(self):
+        """
+        The settings for a blank incoming request can not be kept and must not be restarted
+        """
+        reset, keep = _analyze_current_settings("tenant.com")
+        self.assertFalse(reset)
+        self.assertFalse(keep)
+
+    def test__analyze_current_settings_incorrect_domain(self):
+        """
+        The settings a domain with a different domain to the one currently in
+        """
+        with self.settings(EDNX_TENANT_KEY="different-key",
+                           EDNX_TENANT_DOMAIN="different.com"):
+            reset, keep = _analyze_current_settings("tenant.com")
+
+        self.assertTrue(reset)
+        self.assertFalse(keep)
+
+    def test__analyze_current_settings_correct_domain(self):
+        """
+        The settings a domain with a matching domain to the one currently in
+        """
+        with self.settings(EDNX_TENANT_KEY="tenant-key",
+                           EDNX_TENANT_DOMAIN="tenant.com"):
+            reset, keep = _analyze_current_settings("tenant.com")
+
+        self.assertFalse(reset)
+        self.assertTrue(keep)
+
+
+class SettingsOverridesTest(TestCase):
+    """
+    Special test case that modifies the settings object from the testing process
+    """
+
+    def tearDown(self):
+        """
+        Must reset after every test
+        """
+        from django.conf import settings
+        settings._setup()
+
+    @patch('eox_tenant.signals._get_tenant_config')
+    def test_udpate_settings_mark(self, _get_config_mock):
+        """
+        Settings must only be updated if EDNX_USE_SIGNAL is present
+        """
+        from django.conf import settings
+        config = {
+        }
+        _get_config_mock.return_value = config, "tenant-key"
+
+        _update_settings("tenant.com")
+
+        with self.assertRaises(AttributeError):
+            settings.EDNX_TENANT_KEY
+
+    @patch('eox_tenant.signals._get_tenant_config')
+    def test_udpate_settings(self, _get_config_mock):
+        """
+        Settings must only be updated if EDNX_USE_SIGNAL is present
+        """
+        from django.conf import settings
+        config = {
+            "EDNX_USE_SIGNAL": True,
+        }
+        _get_config_mock.return_value = config, "tenant-key"
+
+        _update_settings("tenant.com")
+
+        settings.EDNX_TENANT_KEY
+
+    @patch('eox_tenant.signals._get_tenant_config')
+    def test_udpate_settings_with_property(self, _get_config_mock):
+        """
+        Settings must only be updated if EDNX_USE_SIGNAL is present
+        """
+        from django.conf import settings
+        config = {
+            "EDNX_USE_SIGNAL": True,
+            "TEST_PROPERTY": "My value",
+        }
+        _get_config_mock.return_value = config, "tenant-key"
+
+        _update_settings("tenant.com")
+
+        self.assertEquals(settings.TEST_PROPERTY, "My value")
+
+    @patch('eox_tenant.signals._get_tenant_config')
+    def test_udpate_settings_with_dict(self, _get_config_mock):
+        """
+        Settings must only be updated if EDNX_USE_SIGNAL is present
+        """
+        from django.conf import settings
+        config = {
+            "EDNX_USE_SIGNAL": True,
+            "TEST_DICT": {
+                "TEST_PROPERTY": "My value",
+            }
+        }
+        _get_config_mock.return_value = config, "tenant-key"
+
+        _update_settings("tenant.com")
+
+        self.assertEquals(settings.TEST_DICT.get("TEST_PROPERTY"), "My value")
+
+
+    @patch('eox_tenant.signals._get_tenant_config')
+    def test_udpate_settings_with_existing_dict(self, _get_config_mock):
+        """
+        Settings must only be updated if EDNX_USE_SIGNAL is present
+        """
+        from django.conf import settings
+        config = {
+            "EDNX_USE_SIGNAL": True,
+            "TEST_DICT_OVERRIDE_TEST": {
+                "key2": "My value",
+            }
+        }
+        _get_config_mock.return_value = config, "tenant-key"
+
+        _update_settings("tenant.com")
+
+        self.assertEquals(settings.TEST_DICT_OVERRIDE_TEST.get("key1"), "Some Value")
+        self.assertEquals(settings.TEST_DICT_OVERRIDE_TEST.get("key2"), "My value")

--- a/requirements.in
+++ b/requirements.in
@@ -5,3 +5,4 @@ futures==3.2.0 ; python_version < "3.0"
 jsonfield==2.0.2
 pylint==1.9.3
 pycodestyle==2.4.0
+mock==2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,17 +11,19 @@ coverage==4.5.1
 django==1.11.15
 edx-opaque-keys==0.4.4
 enum34==1.1.6             # via astroid
+funcsigs==1.0.2           # via mock
 futures==3.2.0 ; python_version < "3.0"
 isort==4.3.4              # via pylint
 jsonfield==2.0.2
 lazy-object-proxy==1.3.1  # via astroid
 mccabe==0.6.1             # via pylint
-pbr==5.1.1                # via stevedore
+mock==2.0.0
+pbr==5.1.1                # via mock, stevedore
 pycodestyle==2.4.0
 pylint==1.9.3
 pymongo==3.7.2            # via edx-opaque-keys
 pytz==2018.7              # via django
 singledispatch==3.4.0.3   # via astroid, pylint
-six==1.11.0               # via astroid, edx-opaque-keys, pylint, singledispatch, stevedore
+six==1.11.0               # via astroid, edx-opaque-keys, mock, pylint, singledispatch, stevedore
 stevedore==1.30.0         # via edx-opaque-keys
 wrapt==1.10.11            # via astroid


### PR DESCRIPTION
This PR defines new functions to be called from the request_started django signal. This will modify the django.conf.settings object for the duration of the python process

Note to reviewers: please go through this soon and be ruthless

TODO
--------
- [x] remove unnecessary modifications
- [x] test on staging
- [x] add unit testing
- [x] rebase after pr#4 is merged

FYI
-----
@jfavellar90 @morenol @Alec4r @andrey-canon 