### PR TITLE
Disabling custom middleware for testing on the platform

### DIFF
--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -19,3 +19,11 @@ MICROSITE_CONFIGURATION_BACKEND = 'eox_tenant.edxapp_wrapper.backends.microsite_
 TEST_DICT_OVERRIDE_TEST = {
     "key1": "Some Value"
 }
+
+
+def plugin_settings(settings):  # pylint: disable=function-redefined
+    """
+    For the platform tests, we want everything to be disabled
+    """
+    settings.FEATURES['USE_MICROSITE_AVAILABLE_SCREEN'] = False
+    settings.FEATURES['USE_REDIRECTION_MIDDLEWARE'] = False


### PR DESCRIPTION
Simple. When we run the tests from the edxapp virtualenv and this is installed, we don't want the redirection middleware being activated because it changes the numbers of queries and a lot of tests break