### PR TITLE
BC21 - Add test to change_domain command.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run --source="." manage.py test
-            coverage report --fail-under=30
+            coverage report --fail-under=40
             pycodestyle ./eox_tenant
             pylint ./eox_tenant --rcfile=./setup.cfg
 
@@ -83,6 +83,6 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run --source="." --rcfile=.coveragerc manage.py test
-            coverage report --fail-under=30 --rcfile=.coveragerc
+            coverage report --fail-under=40 --rcfile=.coveragerc
             pycodestyle ./eox_tenant
             pylint ./eox_tenant --rcfile=./setup.cfg

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ requirements: ## install environment requirements
 
 run-test: clean ## Run test suite.
 	coverage run --source="." manage.py test
-	coverage report --fail-under=30
+	coverage report --fail-under=40
 
 run-quality-test: clean ## Run quality test.
 	pycodestyle ./eox_tenant

--- a/eox_tenant/test/test_change_domain.py
+++ b/eox_tenant/test/test_change_domain.py
@@ -1,0 +1,26 @@
+"""This module include a class that checks the command change_domain.py"""
+
+from django.test import TestCase
+from django.core.management import call_command
+
+from eox_tenant.models import Microsite
+
+
+class ChangeDomainTestCase(TestCase):
+    """ This class checks the command change_domain.py"""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """This method creates Microsite objects in database"""
+
+        Microsite.objects.create(  # pylint: disable=no-member
+            subdomain="first.test.prod.edunext.co")
+
+    def test_domain_can_change(self):
+        """Subdomain has been changed by the command"""
+        call_command('change_domain')
+        prod = Microsite.objects.filter(  # pylint: disable=no-member
+            subdomain="first.test.prod.edunext.co").first()
+        stage = Microsite.objects.filter(  # pylint: disable=no-member
+            subdomain="first-test-prod-edunext-co-stage.edunext.co").first()
+        self.assertIsNone(prod)
+        self.assertIsNotNone(stage)


### PR DESCRIPTION
## Description:

This PR adds test file to change_domain command and also updates the coverage report score to 40.

FYI: 
I forget to add this test file in the [Add eox middlewares PR](https://github.com/eduNEXT/eox-tenant/pull/12).
@felipemontoya 
@diegomillan 