### PR TITLE
HA/EDNX/BC-19 - Using service variant to find cms.

### DIFF
--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -1,7 +1,6 @@
 """
 Common settings for eox_tenant project.
 """
-import os
 
 from .common import *   # pylint: disable=wildcard-import
 
@@ -20,8 +19,6 @@ MICROSITE_CONFIGURATION_BACKEND = 'eox_tenant.edxapp_wrapper.backends.microsite_
 TEST_DICT_OVERRIDE_TEST = {
     "key1": "Some Value"
 }
-
-SETTINGS_MODULE = os.environ.get("DJANGO_SETTINGS_MODULE")
 
 
 def plugin_settings(settings):  # pylint: disable=function-redefined

--- a/eox_tenant/signals.py
+++ b/eox_tenant/signals.py
@@ -146,11 +146,16 @@ def start_tenant(sender, environ, **kwargs):  # pylint: disable=unused-argument
     Signal: django.core.signals.request_started
     """
 
-    if base_settings.SETTINGS_MODULE.startswith("cms"):
+    http_host = environ.get("HTTP_HOST")
+    if not http_host:
+        LOG.warning("Could not find the host information for eox_tenant.signals")
+        return
+
+    if base_settings.SERVICE_VARIANT == "cms":
         LOG.debug("Studio does not support eox_tenant signals yet")
         return
 
-    domain = environ.get("HTTP_HOST").split(':')[0]
+    domain = http_host.split(':')[0]
 
     # Find what we need to do about the current setting and the incoming request.domain
     must_reset, can_keep = _analyze_current_settings(domain)

--- a/eox_tenant/test/test_signals.py
+++ b/eox_tenant/test/test_signals.py
@@ -24,12 +24,13 @@ class StartTenantSignalTest(TestCase):
 
     def test_nothing_changes_studio(self):
         """
-        The cms should return inmediatly, not even try to get the domain
+        The cms should return immediately, just one call must be made it,
+        in order to get the HTTP_HOST from environ variable.
         """
         environ = MagicMock()
-        with self.settings(SETTINGS_MODULE='cms'):
+        with self.settings(SERVICE_VARIANT='cms'):
             start_tenant(None, environ)
-            environ.get.assert_not_called()
+            environ.get.assert_called_once()
 
     @patch('eox_tenant.signals._analyze_current_settings')
     @patch('eox_tenant.signals._perform_reset')
@@ -43,7 +44,7 @@ class StartTenantSignalTest(TestCase):
 
         _analyze_mock.return_value = (True, None)
 
-        with self.settings(SETTINGS_MODULE='lms'):
+        with self.settings(SERVICE_VARIANT='lms'):
             start_tenant(None, environ)
 
         _reset_mock.assert_called()
@@ -62,7 +63,7 @@ class StartTenantSignalTest(TestCase):
         _analyze_mock.return_value = (False, None)
         _ttl_mock.return_value = True
 
-        with self.settings(SETTINGS_MODULE='lms'):
+        with self.settings(SERVICE_VARIANT='lms'):
             start_tenant(None, environ)
 
         _reset_mock.assert_called()
@@ -80,7 +81,7 @@ class StartTenantSignalTest(TestCase):
 
         _analyze_mock.return_value = (False, False)
 
-        with self.settings(SETTINGS_MODULE='lms'):
+        with self.settings(SERVICE_VARIANT='lms'):
             start_tenant(None, environ)
 
         _reset_mock.assert_not_called()
@@ -99,7 +100,7 @@ class StartTenantSignalTest(TestCase):
 
         _analyze_mock.return_value = (False, True)
 
-        with self.settings(SETTINGS_MODULE='lms'):
+        with self.settings(SERVICE_VARIANT='lms'):
             start_tenant(None, environ)
 
         _reset_mock.assert_not_called()


### PR DESCRIPTION
## Description:

This PR goes back to use SERVICE_VARIANT to check if the request comes from either, cms or lms.

## Reviewers:

 - [x] @felipemontoya 