### PR TITLE
Correcting the database name to match prod db

### DIFF
--- a/eox_tenant/migrations/0001_initial.py
+++ b/eox_tenant/migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                 ('values', jsonfield.fields.JSONField(blank=True)),
             ],
             options={
-                'db_table': 'ednx_microsites_microsites',
+                'db_table': 'ednx_microsites_microsite',
             },
         ),
     ]

--- a/eox_tenant/models.py
+++ b/eox_tenant/models.py
@@ -32,7 +32,7 @@ class Microsite(models.Model):
         Model meta class.
         """
         # Note to ops: The table already exists under a different name due to the migration from EOE.
-        db_table = 'ednx_microsites_microsites'
+        db_table = 'ednx_microsites_microsite'
         app_label = "eox_tenant"
 
     def __unicode__(self):


### PR DESCRIPTION
This PR solves the error raised when we used this on a db that was copied from production. The table name had an incorrect name.

For local environments, a new `./load-db edxapp` command must be issued