### PR TITLE
Adding command to modify tenants over a cli.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run --source="." manage.py test
-            coverage report --fail-under=40
+            coverage report --fail-under=48
             pycodestyle ./eox_tenant
             pylint ./eox_tenant --rcfile=./setup.cfg
 
@@ -83,6 +83,6 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run --source="." --rcfile=.coveragerc manage.py test
-            coverage report --fail-under=40 --rcfile=.coveragerc
+            coverage report --fail-under=48 --rcfile=.coveragerc
             pycodestyle ./eox_tenant
             pylint ./eox_tenant --rcfile=./setup.cfg

--- a/eox_tenant/management/commands/change_domain.py
+++ b/eox_tenant/management/commands/change_domain.py
@@ -78,7 +78,6 @@ class Command(BaseCommand):
             message = u"Unable to define stage url for microsite {}".format(
                 subdomain
             )
-            # pylint: disable=no-member
             LOGGER.warning(message)
-            LOGGER.error(exc.message)
+            LOGGER.error(exc.message)  # pylint: disable=no-member
         return stage_domain

--- a/eox_tenant/management/commands/edit_tenant_values.py
+++ b/eox_tenant/management/commands/edit_tenant_values.py
@@ -1,0 +1,160 @@
+"""
+This module contains the command class to modify the values
+from a tenant so that we can add, remove of edit tenants in bulk.
+"""
+from __future__ import unicode_literals
+
+import ast
+import logging
+
+from django.core.management.base import BaseCommand
+from six.moves import input
+
+from eox_tenant.models import Microsite
+
+LOGGER = logging.getLogger(__name__)
+
+
+def tenant_interpolation(value, tenant):
+    """
+    Uses the information on the tenant to interpolate strings
+    """
+    context = {
+        "subdomain": tenant.subdomain,
+        "key": tenant.key,
+    }
+    context.update(tenant.values)
+
+    return value.format(**context)
+
+
+def cast_likely_type(value):
+    """
+    Makes strings like "True" or "None" evaluate to real Bool or None types.
+    """
+    try:
+        # We try to cast is as the most likely type
+        return ast.literal_eval(value)
+    except Exception:  # pylint: disable=broad-except
+        return value
+
+
+class Command(BaseCommand):
+    """
+    Main class handling the execution of the command to alter the sites by adding or removing keys
+
+    Examples:
+    - python manage.py lms edit_tenant_values --add EDNX_USE_SIGNAL True
+    - python manage.py lms edit_tenant_values --delete EDNX_USE_SIGNAL
+
+    Advanced example:
+    - python manage.py lms edit_tenant_values --pattern yoursite.com -v 2 --add NESTED.KEY.NAME {interpolated_value} -f
+    """
+    help = """
+        Exposes a cli to perform bulk modification of eox_tenant sites
+    """
+
+    def add_arguments(self, parser):
+        """
+        Cli definition
+        """
+        # Positional arguments
+        # None for now
+
+        # Named (optional) arguments
+        parser.add_argument(
+            '--add',
+            nargs=2,
+            dest='add',
+        )
+        parser.add_argument(
+            '--delete',
+            nargs="*",
+            dest='delete',
+        )
+        parser.add_argument(
+            '--pattern',
+            nargs=1,
+            dest='pattern',
+        )
+        parser.add_argument(
+            '-f',
+            '--force',
+            dest='force',
+            action='store_true',
+        )
+
+    def handle(self, *args, **options):
+        """
+        Main cli method to iterate over the sites and perform the required modifications
+        """
+
+        if options['verbosity'] > 1:
+            LOGGER.info('Options recognized from the command call')
+            LOGGER.info(options)
+
+        query = Microsite.objects.all()  # pylint: disable=no-member
+
+        if options['pattern']:
+            query = query.filter(subdomain__icontains=options['pattern'][0])
+
+        LOGGER.info("This command will affect the following sites:")
+        for tenant in query:
+            LOGGER.info("{} on: {}".format(tenant, tenant.subdomain))
+
+        if not options['force']:
+            user_response = input("Continue? y/n: ")
+            if user_response != 'y':
+                LOGGER.info("No tenants where modified")
+                return
+
+        for tenant in query:
+            if options['delete']:
+                self.action_delete(tenant, options['delete'])
+
+            if options['add']:
+                self.action_add(tenant, options['add'][0], options['add'][1])
+
+    def action_delete(self, tenant, keys):
+        """
+        Handles removal of keys in the values dict.
+        Keys will be treated as nested dictionaries according
+        to a dot separated notations
+        """
+        for key in keys:
+            try:
+                chain = key.split('.')
+
+                tmp = tenant.values
+                last = chain[-1]
+                for link in chain[:-1]:
+                    tmp = tmp[link]
+                tmp.pop(last)
+
+                tenant.save()
+            except KeyError:
+                LOGGER.info("Could not find key: {} on site {}".format(key, tenant))
+
+    def action_add(self, tenant, key, value):
+        """
+        Handles addition to the values dict.
+        Keys will be treated as nested dictionaries according
+        to a dot separated notations
+        """
+        try:
+            chain = key.split('.')
+
+            tmp = tenant.values
+            last = chain[-1]
+            for link in chain[:-1]:
+                try:
+                    tmp = tmp[link]
+                except KeyError:
+                    tmp[link] = {}
+                    tmp = tmp[link]
+            interpolated_value = tenant_interpolation(value, tenant)
+            tmp[last] = cast_likely_type(interpolated_value)
+
+            tenant.save()
+        except Exception:  # pylint: disable=broad-except
+            LOGGER.info("Could not add key {} to site {}".format(key, tenant))

--- a/eox_tenant/management/commands/edit_tenant_values.py
+++ b/eox_tenant/management/commands/edit_tenant_values.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 import ast
 import logging
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from six.moves import input
 
 from eox_tenant.models import Microsite
@@ -106,7 +106,7 @@ class Command(BaseCommand):
             user_response = input("Continue? y/n: ")
             if user_response != 'y':
                 LOGGER.info("No tenants where modified")
-                return
+                raise CommandError("Canceled by user")
 
         for tenant in query:
             if options['delete']:

--- a/eox_tenant/test/test_change_domain.py
+++ b/eox_tenant/test/test_change_domain.py
@@ -9,7 +9,7 @@ from eox_tenant.models import Microsite
 class ChangeDomainTestCase(TestCase):
     """ This class checks the command change_domain.py"""
 
-    def setUp(self):  # pylint: disable=invalid-name
+    def setUp(self):
         """This method creates Microsite objects in database"""
 
         Microsite.objects.create(  # pylint: disable=no-member

--- a/eox_tenant/test/test_edit_tenant_values.py
+++ b/eox_tenant/test/test_edit_tenant_values.py
@@ -1,0 +1,83 @@
+"""This module include a class that checks the command change_domain.py"""
+from django.test import TestCase
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from mock import patch
+
+
+from eox_tenant.models import Microsite
+
+
+class EditTenantValuesTestCase(TestCase):
+    """ This class checks the command edit_tenant_values.py"""
+
+    def setUp(self):
+        """This method creates Microsite objects in database"""
+        Microsite.objects.create(  # pylint: disable=no-member
+            key="test",
+            subdomain="first.test.prod.edunext.co",
+            values={
+                "KEY": "value",
+                "NESTED_KEY": {"key": "value"},
+            })
+
+    @patch('eox_tenant.management.commands.edit_tenant_values.input', return_value='y')
+    def test_command_can_be_called(self, _):
+        """Tests that we can actually run the command"""
+        call_command('edit_tenant_values')
+
+    @patch('eox_tenant.management.commands.edit_tenant_values.input', return_value='n')
+    def test_command_exec_confirmation_false(self, _):
+        """Tests that when the confirmation returns other than 'y' we raise the abort error"""
+        with self.assertRaises(CommandError):
+            call_command('edit_tenant_values')
+
+    @patch('eox_tenant.management.commands.edit_tenant_values.input', return_value='y')
+    def test_command_exec_confirmation_add(self, _):
+        """Tests that we can add a new key"""
+        call_command('edit_tenant_values', '--add', 'NEW_KEY', 'NEW_VALUE')
+        tenant = Microsite.objects.get(key='test')  # pylint: disable=no-member
+        self.assertIn('NEW_KEY', tenant.values)
+        self.assertEqual('NEW_VALUE', tenant.values.get('NEW_KEY'))
+
+    @patch('eox_tenant.management.commands.edit_tenant_values.input', return_value='y')
+    def test_command_exec_confirmation_add_nested(self, _):
+        """Tests that we can add a new nested key"""
+        call_command('edit_tenant_values', '--add', 'NEW_KEY.nested', 'NEW_VALUE')
+        tenant = Microsite.objects.get(key='test')  # pylint: disable=no-member
+        self.assertIn('nested', tenant.values.get('NEW_KEY'))
+        self.assertEqual('NEW_VALUE', tenant.values.get('NEW_KEY').get('nested'))
+
+    @patch('eox_tenant.management.commands.edit_tenant_values.input', return_value='y')
+    def test_command_exec_confirmation_delete(self, _):
+        """Tests that we can remove a key"""
+        call_command('edit_tenant_values', '--delete', 'KEY')
+        tenant = Microsite.objects.get(key='test')  # pylint: disable=no-member
+        self.assertNotIn('KEY', tenant.values)
+
+    @patch('eox_tenant.management.commands.edit_tenant_values.input', return_value='y')
+    def test_command_exec_confirmation_delete_chain(self, _):
+        """Tests that we can remove a nested key"""
+        call_command('edit_tenant_values', '--delete', 'NESTED_KEY.key')
+        tenant = Microsite.objects.get(key='test')  # pylint: disable=no-member
+        self.assertIn('NESTED_KEY', tenant.values)
+        self.assertNotIn('key', tenant.values.get('NESTED_KEY'))
+
+    @patch('eox_tenant.management.commands.edit_tenant_values.input', return_value='y')
+    def test_command_exec_confirmation_pattern(self, _):
+        """Tests that we can affect only the sites defined by a pattern in their subdomain"""
+        # pylint: disable=no-member
+        Microsite.objects.create(
+            key="test2",
+            subdomain="second.test.prod.edunext.co",
+            values={
+                "KEY": "value",
+                "NESTED_KEY": {"key": "value"},
+            })
+
+        call_command('edit_tenant_values', '--delete', 'KEY', '--pattern', 'second.test.prod.edunext.co')
+        tenant1 = Microsite.objects.get(key='test')
+        tenant2 = Microsite.objects.get(key='test2')
+
+        self.assertIn('KEY', tenant1.values)
+        self.assertNotIn('KEY', tenant2.values)


### PR DESCRIPTION
This PR adds a new edit_tenant_values django command.

The command supports adding and removing nested keys and using basic interpolation with the tenant values. Also supports pattern filtering to select the sites it will operate on.