### PR TITLE
HA/EDNX/HA-23 - Fix site not found middleware error.

### DIFF
--- a/eox_tenant/backends/database.py
+++ b/eox_tenant/backends/database.py
@@ -30,13 +30,7 @@ class EdunextCompatibleDatabaseMicrositeBackend(BaseMicrositeBackend):
         """
         We always require a configuration to function, so we can skip the query
         """
-        return True
-
-    def is_request_in_microsite(self):
-        """
-        We always require a configuration to function, so we can skip the query
-        """
-        return True
+        return settings.FEATURES.get('USE_MICROSITES', False)
 
     def iterate_sites(self):
         """


### PR DESCRIPTION
## Description:

During stage testing, when we try to go to unknow microsite url, the RedirectionsMiddleware does not redirect to the 404 page. This patch removes the is_request_in_microsite since the right implementation is already in the base.py backend, and adds a reading of USE_MICROSITES settings in has_configuration_set().

## Reviewers:

 - [ ] @felipemontoya 