### PR TITLE
Reloading apps as configured in the tenant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run --source="." manage.py test
-            coverage report --fail-under=51
+            coverage report --fail-under=51 -m
             pycodestyle ./eox_tenant
             pylint ./eox_tenant --rcfile=./setup.cfg
 
@@ -83,6 +83,6 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run --source="." --rcfile=.coveragerc manage.py test
-            coverage report --fail-under=51 --rcfile=.coveragerc
+            coverage report --fail-under=51 --rcfile=.coveragerc -m
             pycodestyle ./eox_tenant
             pylint ./eox_tenant --rcfile=./setup.cfg

--- a/eox_tenant/signals.py
+++ b/eox_tenant/signals.py
@@ -25,6 +25,8 @@ import os
 from datetime import datetime
 
 import six
+
+from django.apps.config import AppConfig
 from django.conf import settings as base_settings
 
 from eox_tenant.backends.database import EdunextCompatibleDatabaseMicrositeBackend
@@ -71,8 +73,6 @@ def _repopulate_apps(apps):
     We delegate the decision to the specific tenant on the EDNX_TENANT_INSTALLED_APPS key.
     If present, the key is passed in the apps argument
     """
-    from django.apps.config import AppConfig
-
     LOG.debug("PID: %s REPOPULATING APPS | %s", os.getpid(), apps)
     for entry in apps:
         app_config = AppConfig.create(entry)

--- a/eox_tenant/signals.py
+++ b/eox_tenant/signals.py
@@ -63,6 +63,22 @@ def _update_settings(domain):
         setattr(base_settings, key, value)
 
 
+def _repopulate_apps(apps):
+    """
+    After the initial loading of the settings, some djangoapps can override the AppConfig.ready() method
+    to alter the settings in a particular way.
+    In this case we need to run the app config again.
+    We delegate the decision to the specific tenant on the EDNX_TENANT_INSTALLED_APPS key.
+    If present, the key is passed in the apps argument
+    """
+    from django.apps.config import AppConfig
+
+    LOG.debug("PID: %s REPOPULATING APPS | %s", os.getpid(), apps)
+    for entry in apps:
+        app_config = AppConfig.create(entry)
+        app_config.ready()
+
+
 def _analyze_current_settings(domain):
     """
     The logic in here will determine if the current settings object has already been
@@ -175,6 +191,13 @@ def start_tenant(sender, environ, **kwargs):  # pylint: disable=unused-argument
 
     # Do the update
     _update_settings(domain)
+
+    # Some django apps need to be reinitialized
+    try:
+        if base_settings.EDNX_TENANT_INSTALLED_APPS:
+            _repopulate_apps(base_settings.EDNX_TENANT_INSTALLED_APPS)
+    except AttributeError:
+        pass
 
 
 def finish_tenant(sender, **kwargs):  # pylint: disable=unused-argument


### PR DESCRIPTION
This PR allows a particular tenant to reload the AppConfig from a INSTALLED_APP after the settings are reset.

This  fixes the issue we had on the ThirdPartyAuth sad paths.
The method called here: https://github.com/eduNEXT/edunext-platform/blob/master/common/djangoapps/third_party_auth/apps.py#L15 overrides some settings that where reset on the signal call.

We allow a tenant to decide if it wants any app being reloaded again using `EDNX_TENANT_INSTALLED_APPS`




