### PR TITLE
Improving a bit the change_domain command

### DIFF
--- a/eox_tenant/management/commands/change_domain.py
+++ b/eox_tenant/management/commands/change_domain.py
@@ -68,8 +68,11 @@ class Command(BaseCommand):
         my-microsite-domain-{suffix_stage_domain}
         """
 
+        pre_formatted = "{}-{}"
+        if self.suffix_stage_domain.startswith("."):
+            pre_formatted = "{}{}"
         try:
-            stage_domain = "{}-{}".format(
+            stage_domain = pre_formatted.format(
                 subdomain.replace('.', '-'),
                 self.suffix_stage_domain
             )

--- a/eox_tenant/management/commands/change_domain.py
+++ b/eox_tenant/management/commands/change_domain.py
@@ -6,6 +6,7 @@ import json
 import logging
 
 from django.conf import settings
+from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 
 from eox_tenant.models import Microsite
@@ -38,6 +39,7 @@ class Command(BaseCommand):
 
         self.suffix_stage_domain = options['suffix_domain']
 
+        # Changing microsites objects
         for microsite in Microsite.objects.all():  # pylint: disable=no-member
 
             # Don't bother on changing anything if the suffix is correct
@@ -61,6 +63,20 @@ class Command(BaseCommand):
             )
             microsite.values = json.loads(modified_configs_string)
             microsite.save()
+
+        # Changing django sites objects
+        for site in Site.objects.all():
+            if site.domain.endswith(self.suffix_stage_domain):
+                continue
+
+            stage_domain = self.change_subdomain(site.domain)
+
+            if not stage_domain:
+                continue
+
+            site.domain = stage_domain
+            site.name = stage_domain
+            site.save()
 
     def change_subdomain(self, subdomain):
         """

--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -13,6 +13,13 @@ class SettingsClass(object):
 SETTINGS = SettingsClass()
 plugin_settings(SETTINGS)
 vars().update(SETTINGS.__dict__)
+INSTALLED_APPS = vars().get("INSTALLED_APPS", [])
+TEST_INSTALLED_APPS = [
+    "django.contrib.sites",
+]
+for app in TEST_INSTALLED_APPS:
+    if app not in INSTALLED_APPS:
+        INSTALLED_APPS.append(app)
 
 MICROSITE_CONFIGURATION_BACKEND = 'eox_tenant.edxapp_wrapper.backends.microsite_configuration_test_v1'
 

--- a/eox_tenant/test/test_change_domain.py
+++ b/eox_tenant/test/test_change_domain.py
@@ -24,3 +24,13 @@ class ChangeDomainTestCase(TestCase):
             subdomain="first-test-prod-edunext-co-stage.edunext.co").first()
         self.assertIsNone(prod)
         self.assertIsNotNone(stage)
+
+    def test_domain_can_change_with_point(self):
+        """Subdomain has been changed by the command"""
+        call_command('change_domain', suffix_domain=".stage.edunext.co")
+        prod = Microsite.objects.filter(  # pylint: disable=no-member
+            subdomain="first.test.prod.edunext.co").first()
+        stage = Microsite.objects.filter(  # pylint: disable=no-member
+            subdomain="first-test-prod-edunext-co.stage.edunext.co").first()
+        self.assertIsNone(prod)
+        self.assertIsNotNone(stage)

--- a/eox_tenant/test/test_change_domain.py
+++ b/eox_tenant/test/test_change_domain.py
@@ -1,6 +1,7 @@
 """This module include a class that checks the command change_domain.py"""
 
 from django.test import TestCase
+from django.contrib.sites.models import Site
 from django.core.management import call_command
 
 from eox_tenant.models import Microsite
@@ -14,6 +15,9 @@ class ChangeDomainTestCase(TestCase):
 
         Microsite.objects.create(  # pylint: disable=no-member
             subdomain="first.test.prod.edunext.co")
+        Site.objects.create(  # pylint: disable=no-member
+            domain="second.test.prod.edunext.co",
+            name="second.test.prod.edunext.co")
 
     def test_domain_can_change(self):
         """Subdomain has been changed by the command"""
@@ -24,6 +28,12 @@ class ChangeDomainTestCase(TestCase):
             subdomain="first-test-prod-edunext-co-stage.edunext.co").first()
         self.assertIsNone(prod)
         self.assertIsNotNone(stage)
+        prod_site = Site.objects.filter(  # pylint: disable=no-member
+            domain="second.test.prod.edunext.co").first()
+        stage_site = Site.objects.filter(  # pylint: disable=no-member
+            domain="second-test-prod-edunext-co-stage.edunext.co").first()
+        self.assertIsNone(prod_site)
+        self.assertIsNotNone(stage_site)
 
     def test_domain_can_change_with_point(self):
         """Subdomain has been changed by the command"""
@@ -34,3 +44,9 @@ class ChangeDomainTestCase(TestCase):
             subdomain="first-test-prod-edunext-co.stage.edunext.co").first()
         self.assertIsNone(prod)
         self.assertIsNotNone(stage)
+        prod_site = Site.objects.filter(  # pylint: disable=no-member
+            domain="second.test.prod.edunext.co").first()
+        stage_site = Site.objects.filter(  # pylint: disable=no-member
+            domain="second-test-prod-edunext-co.stage.edunext.co").first()
+        self.assertIsNone(prod_site)
+        self.assertIsNotNone(stage_site)


### PR DESCRIPTION
This PR allows to control in a better way how the stage domains are build. Specifically in the case where the provided suffix domains starts with a dot, for example ".i.stage.edunext.co". In this case we don't need a hyphen (-) as separator of the transformed microsite domain and the suffix.

@morenol 
@cocococosti 
@felipemontoya 