### PR TITLE
Jhony/fix filter enrollments

### DIFF
--- a/eox_tenant/backends/database.py
+++ b/eox_tenant/backends/database.py
@@ -11,7 +11,11 @@ from eox_tenant.backends.base import BaseMicrositeBackend
 from eox_tenant.edxapp_wrapper.get_common_util import strip_port_from_host
 
 MICROSITES_ALL_ORGS_CACHE_KEY = 'microsites.all_orgs_list'
-MICROSITES_ALL_ORGS_CACHE_KEY_TIMEOUT = 300  # In seconds
+MICROSITES_ALL_ORGS_CACHE_KEY_TIMEOUT = getattr(
+    settings,
+    'MICROSITES_ALL_ORGS_CACHE_KEY_TIMEOUT',
+    300
+)
 
 
 class EdunextCompatibleDatabaseMicrositeBackend(BaseMicrositeBackend):

--- a/eox_tenant/settings/aws.py
+++ b/eox_tenant/settings/aws.py
@@ -27,6 +27,10 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'CHANGE_DOMAIN_DEFAULT_SITE_NAME',
         settings.CHANGE_DOMAIN_DEFAULT_SITE_NAME
     )
+    settings.MICROSITES_ALL_ORGS_CACHE_KEY_TIMEOUT = getattr(settings, 'ENV_TOKENS', {}).get(
+        'MICROSITES_ALL_ORGS_CACHE_KEY_TIMEOUT',
+        settings.MICROSITES_ALL_ORGS_CACHE_KEY_TIMEOUT
+    )
 
     if settings.SERVICE_VARIANT == "lms":
         settings.MIDDLEWARE_CLASSES += [

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -39,6 +39,7 @@ def plugin_settings(settings):
     settings.MICROSITE_TEMPLATE_BACKEND = \
         'eox_tenant.backends.filebased.EdunextCompatibleFilebasedMicrositeTemplateBackend'
     settings.MICROSITE_CONFIGURATION_BACKEND = 'eox_tenant.edxapp_wrapper.backends.microsite_configuration_h_v1'
+    settings.MICROSITES_ALL_ORGS_CACHE_KEY_TIMEOUT = 300
     settings.GET_CONFIGURATION_HELPERS = 'eox_tenant.edxapp_wrapper.backends.configuration_helpers_h_v1'
     settings.GET_BRANDING_API = 'eox_tenant.edxapp_wrapper.backends.branding_api_h_v1'
     settings.EOX_MAX_CONFIG_OVERRIDE_SECONDS = 300

--- a/eox_tenant/tenant_aware_functions/enrollments.py
+++ b/eox_tenant/tenant_aware_functions/enrollments.py
@@ -22,18 +22,23 @@ def filter_enrollments(enrollments):
         return
 
     orgs_to_include = get_microsite().get_value('course_org_filter')
-    orgs_to_exclude = get_microsite().get_all_orgs()
+    orgs_to_exclude = []
 
-    if orgs_to_include:
-        # Make sure we dont exclude one of the included orgs, when the data is contradictory
-        orgs_to_exclude = [x for x in orgs_to_exclude if x not in orgs_to_include]
+    # Make sure we have a list
+    if orgs_to_include and not isinstance(orgs_to_include, list):
+        orgs_to_include = [orgs_to_include]
+
+    if not orgs_to_include:
+        # Making orgs_to_include an empty iterable
+        orgs_to_include = []
+        orgs_to_exclude = get_microsite().get_all_orgs()
 
     for enrollment in enrollments:
 
         org = enrollment.course_id.org
 
         # Filter out anything that is not attributed to the inclusion rule.
-        if orgs_to_include and org not in orgs_to_include:
+        if org not in orgs_to_include:
             continue
 
         # Conversely, filter out any enrollments with courses attributed to exclusion rule.

--- a/eox_tenant/test/test_tenant_aware_functions.py
+++ b/eox_tenant/test/test_tenant_aware_functions.py
@@ -1,0 +1,99 @@
+"""This module include a class that checks the tenant aware functions"""
+import mock
+
+from django.test import TestCase, override_settings
+
+from eox_tenant.tenant_aware_functions.enrollments import filter_enrollments
+
+
+class TenantAwareFunctionsTestCase(TestCase):
+    """ This class checks the command change_domain.py"""
+
+    def setUp(self):
+        """This method creates Microsite objects in database"""
+
+        # Creating mock enrollments
+        orgs_for_enrolls = ['org1', 'org2', 'org3', 'org3']
+        enrolls = []
+        for org in orgs_for_enrolls:
+            enroll_mock = mock.MagicMock()
+            enroll_mock.course_id.org = org
+            enrolls.append(enroll_mock)
+        self.enrolls = enrolls
+
+    @override_settings(EOX_TENANT_SKIP_FILTER_FOR_TESTS=True)
+    def test_filter_enrollments_dont_filter(self):
+        """
+        Test the case when the filter is not applied because the
+        EOX_TENANT_SKIP_FILTER_FOR_TESTS setting is activated
+        """
+        result = filter_enrollments(self.enrolls)
+        self.assertEqual(len(list(result)), 4)
+
+    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.get_microsite')
+    def test_filter_enrollments_not_request_in_microsite(self, get_microsite_mock):
+        """
+        Test the case when the request is not in a microsite (filter is not applied)
+        """
+        microsite_module_mock = mock.MagicMock()
+        microsite_module_mock.is_request_in_microsite.return_value = False
+        get_microsite_mock.return_value = microsite_module_mock
+
+        result = filter_enrollments(self.enrolls)
+        self.assertEqual(len(list(result)), 4)
+
+        microsite_module_mock.is_request_in_microsite.assert_called_once()
+
+    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.get_microsite')
+    def test_filter_enrollments_function(self, get_microsite_mock):
+        """
+        Test that the filter works properly
+        """
+        results_get_value = {
+            'course_org_filter': ['org2']
+        }
+
+        def side_effect_get_value(key, default=None):
+            """
+            Mock side effect
+            """
+            return results_get_value.get(key, default)
+
+        microsite_module_mock = mock.MagicMock()
+        microsite_module_mock.get_value.side_effect = side_effect_get_value
+        microsite_module_mock.is_request_in_microsite.return_value = True
+        get_microsite_mock.return_value = microsite_module_mock
+
+        result = filter_enrollments(self.enrolls)
+        list_result = list(result)
+        self.assertEqual(len(list_result), 1)
+        self.assertEqual(list_result[0].course_id.org, 'org2')
+
+        microsite_module_mock.is_request_in_microsite.assert_called_once()
+        microsite_module_mock.get_value.assert_called_once()
+
+    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.get_microsite')
+    def test_filter_enrollments_no_org_filter(self, get_microsite_mock):
+        """
+        Test the case when the microsite does not have a course_org_filter
+        """
+        results_get_value = {}
+
+        def side_effect_get_value(key, default=None):
+            """
+            Mock side effect
+            """
+            return results_get_value.get(key, default)
+
+        microsite_module_mock = mock.MagicMock()
+        microsite_module_mock.get_value.side_effect = side_effect_get_value
+        microsite_module_mock.is_request_in_microsite.return_value = True
+        microsite_module_mock.get_all_orgs.return_value = ['org1', 'org2', 'org3', 'org3']
+        get_microsite_mock.return_value = microsite_module_mock
+
+        result = filter_enrollments(self.enrolls)
+        self.assertEqual(len(list(result)), 0)
+
+        microsite_module_mock.is_request_in_microsite.assert_called_once()
+        microsite_module_mock.get_value.assert_called_once()
+        microsite_module_mock.get_all_orgs.assert_called_once()


### PR DESCRIPTION
This PR mitigates the high cost that implies calling the get_all_orgs function from our microsite backend. Basically there are two changes:

- The method filter_enrollments does not call get_all_orgs method from the microsite backend unless it's strictly necessary.
- The result of the method get_all_orgs from the microsite backend is cached during 5 minutes

@diegomillan 
@felipemontoya 
@anmrdz 
@Squirrel18 