### PR TITLE
Create command for tenant config

### DIFF
--- a/eox_tenant/management/commands/use_tenantconfig.py
+++ b/eox_tenant/management/commands/use_tenantconfig.py
@@ -1,0 +1,96 @@
+"""
+This module contains the command class to migrate the site
+configurations and microsites data to the TenantConfig .
+"""
+from django.contrib.sites.models import Site
+from django.core.management.base import BaseCommand, CommandError
+
+from eox_tenant.models import Microsite, TenantConfig, Route
+from eox_tenant.utils import fasthash
+
+
+class Command(BaseCommand):
+
+    """
+    This class contains the methods to create
+    tenant configs from sites and microsites.
+    """
+    help = """This function will iterate over all microsites an site-configuration objects
+            an create a tenant config and the route objects with their information."""
+
+    def add_arguments(self, parser):
+        parser.add_argument('--site-configurations', action="store_true", dest='siteconfigurations', default=False)
+        parser.add_argument('--microsites', action="store_true", dest='microsites', default=False)
+
+    def handle(self, *args, **options):
+        """
+        This method will iterate over all microsites and site objects to
+        create the route and the tenant config objects with their information.
+        """
+
+        if not options['microsites'] and not options['siteconfigurations']:
+            raise CommandError("Use --microsites and/or --site-configurations options.")
+
+        if options['microsites']:
+
+            # Iterating microsites objects
+            for microsite in Microsite.objects.all():  # pylint: disable=no-member
+                try:
+                    route = Route.objects.get(domain=microsite.subdomain)  # pylint: disable=no-member
+                except Route.DoesNotExist:  # pylint: disable=no-member
+                    route = None
+
+                try:
+                    tenant = TenantConfig.objects.get(external_key=microsite.key)
+                except TenantConfig.DoesNotExist:  # pylint: disable=no-member
+                    tenant = None
+
+                #  If there is a route do nothing.
+                if route:
+                    continue
+
+                if not tenant:
+                    tenant = TenantConfig(
+                        external_key=microsite.key,
+                        lms_configs=microsite.values)
+                    tenant.save()
+
+                route = Route(domain=microsite.subdomain, config=tenant)
+                route.save()
+
+        if options['siteconfigurations']:
+
+            # Iterating django sites objects
+            for site in Site.objects.all():
+
+                # Only do the changes for the site_configurations enabled
+                try:
+                    if not site.configuration.enabled:
+                        continue
+                except AttributeError:
+                    continue
+
+                try:
+                    route = Route.objects.get(domain=site.domain)  # pylint: disable=no-member
+                except Route.DoesNotExist:  # pylint: disable=no-member
+                    route = None
+
+                api_key = fasthash(site.domain)
+
+                try:
+                    tenant = TenantConfig.objects.get(external_key=api_key)
+                except TenantConfig.DoesNotExist:  # pylint: disable=no-member
+                    tenant = None
+
+                # If there is a route do nothing.
+                if route:
+                    continue
+
+                if not tenant:
+                    tenant = TenantConfig(
+                        external_key=api_key,
+                        lms_configs=site.configuration.values)
+                    tenant.save()
+
+                route = Route(domain=site.domain, config=tenant)
+                route.save()

--- a/eox_tenant/test/test_use_tenantconfig.py
+++ b/eox_tenant/test/test_use_tenantconfig.py
@@ -1,0 +1,60 @@
+"""This module include a class that checks the command change_domain.py"""
+
+import mock
+
+from django.test import TestCase
+from django.contrib.sites.models import Site
+from django.core.management import call_command
+
+from eox_tenant.models import Microsite, Route, TenantConfig
+
+
+class ChangeDomainTestCase(TestCase):
+    """ This class checks the command use_tenantconfig.py"""
+
+    def setUp(self):
+        """This created the objects used in  the tests"""
+
+        Microsite.objects.create(  # pylint: disable=no-member
+            subdomain="first.test.prod.edunext.co")
+        Site.objects.create(
+            domain="second.test.prod.edunext.co",
+            name="second.test.prod.edunext.co")
+
+    def test_route_created(self):
+        """Route has been created by the command"""
+        call_command('use_tenantconfig', microsites=True)
+
+        route = Route.objects.filter(domain="first.test.prod.edunext.co").first()  # pylint: disable=no-member
+        self.assertIsNotNone(route)
+
+    def test_call_command_twice(self):
+        """There is created only one TenantConfig by the command"""
+        call_command('use_tenantconfig', microsites=True)
+        call_command('use_tenantconfig', microsites=True)
+
+        tenants = TenantConfig.objects.all().count()
+
+        self.assertEqual(1, tenants)
+
+    def test_site_without_siteconfig(self):
+        """Test that the command does not create nothing when there is not site configuration"""
+        call_command('use_tenantconfig', siteconfigurations=True)
+        route = Route.objects.filter(domain="second.test.prod.edunext.co").first()  # pylint: disable=no-member
+
+        self.assertIsNone(route)
+
+    @mock.patch('django.contrib.sites.models.Site.objects.all')
+    def test_route_created_siteconfig(self, siteconfig_mock):
+        """TRoute has been created by the command using site configurations"""
+        site = mock.Mock(spec=Site)
+        site.domain = "second.test.prod.edunext.co"
+        site.configuration = mock.Mock()
+        site.configuration.enabled = True
+        site.configuration.values = {}
+        siteconfig_mock.return_value = [site]
+
+        call_command('use_tenantconfig', siteconfigurations=True)
+
+        route = Route.objects.filter(domain="second.test.prod.edunext.co").first()  # pylint: disable=no-member
+        self.assertIsNotNone(route)

--- a/eox_tenant/utils.py
+++ b/eox_tenant/utils.py
@@ -17,5 +17,5 @@ def fasthash(string):
     Hashes `string` into a string representation of a 128-bit digest.
     """
     md4 = hashlib.new("md4")
-    md4.update(string)
+    md4.update(string.encode('utf-8'))
     return md4.hexdigest()


### PR DESCRIPTION
This PR creates a command to migrate the handling of the tenant from microsites - siteconfigurations to the tenantconfig model 