### PR TITLE
[WIP] Ir/ednx/ir 20

### DIFF
--- a/eox_tenant/auth.py
+++ b/eox_tenant/auth.py
@@ -1,0 +1,82 @@
+
+"""
+This file implements the authentication backend for the openedx platform.
+"""
+import logging
+import re
+
+from django.conf import settings
+from django.contrib.auth import get_user_model
+
+from django.utils.translation import ugettext as _
+
+from eox_tenant.edxapp_wrapper.auth import get_edx_auth_backend, get_edx_auth_failed
+
+AuthFailedError = get_edx_auth_failed()
+AUDIT_LOG = logging.getLogger("audit")
+EdxAuthBackend = get_edx_auth_backend()
+UserModel = get_user_model()
+
+
+class TenantAwareAuthBackend(EdxAuthBackend):
+    """
+    Authentication Backend class which will check if the user has a signupsource in the requested site.
+    """
+    def authenticate(self, request, **kwargs):
+        """
+        Override default method to store the request which is being used by the
+        user_can_authenticate_on_tenant method.
+        """
+        self.request = request  # pylint: disable=attribute-defined-outside-init
+        return super(TenantAwareAuthBackend, self).authenticate(
+            request=request, **kwargs
+        )
+
+    def user_can_authenticate(self, user):
+        """
+        Override user_can_authenticate method with the logic to be tenant aware.
+        """
+        if not settings.FEATURES.get("EDNX_TENANT_AWARE_AUTH", False):
+            return super(TenantAwareAuthBackend, self).user_can_authenticate(user)
+
+        return self.user_can_authenticate_on_tenant(user)
+
+    def user_can_authenticate_on_tenant(self, user):
+        """
+        Prevent users that signed up on a different tenant site to login in this site.
+        """
+        current_domain = self.request.META.get("HTTP_HOST")
+
+        authorized_sources = getattr(settings, 'EDNX_ACCOUNT_REGISTRATION_SOURCES', [current_domain])
+        sources = user.usersignupsource_set.all()
+
+        is_authorized = False
+        for source in sources:
+            if any(re.match(pattern + "$", source.site) for pattern in authorized_sources):
+                is_authorized = True
+
+        email = getattr(user, 'email', None)
+        if settings.REGISTRATION_EMAIL_PATTERNS_ALLOWED is not None:
+            # Taken from forms.AccountCreationForm
+            allowed_patterns = settings.REGISTRATION_EMAIL_PATTERNS_ALLOWED
+            if not any(re.match(pattern + "$", email) for pattern in allowed_patterns):
+                # This email is not on the whitelist of allowed emails.
+                is_authorized = False
+
+        if not is_authorized:
+            loggable_id = user.id if user else "<unknown>"
+            if settings.FEATURES.get('EDNX_ENABLE_STRICT_LOGIN', False):
+                AUDIT_LOG.warning(
+                    u"User `%s` tried to login in site `%s`, but was denied permission based on the signup sources.",
+                    loggable_id,
+                    current_domain,
+                )
+                raise AuthFailedError(_('User not authorized to perform this action'))
+            else:
+                AUDIT_LOG.warning(
+                    u"User `%s` tried to login in site `%s`, the permission "
+                    "should have beed denied based on the signup sources.",
+                    loggable_id,
+                    current_domain,
+                )
+        return True

--- a/eox_tenant/edxapp_wrapper/auth.py
+++ b/eox_tenant/edxapp_wrapper/auth.py
@@ -1,0 +1,24 @@
+"""
+Auth definitions.
+"""
+
+from importlib import import_module
+from django.conf import settings
+
+
+def get_edx_auth_backend():
+    """ Get Edx Authentication Backend model. """
+
+    backend_function = settings.EOX_TENANT_EDX_AUTH_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.get_edx_auth_backend()
+
+
+def get_edx_auth_failed():
+    """ Get the AuthFailed Class. """
+
+    backend_function = settings.EOX_TENANT_EDX_AUTH_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.get_edx_auth_failed()

--- a/eox_tenant/edxapp_wrapper/backends/edx_auth_i_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/edx_auth_i_v1.py
@@ -1,0 +1,13 @@
+""" Backend abstraction. """
+from openedx.core.djangoapps.oauth_dispatch.dot_overrides.backends import EdxRateLimitedAllowAllUsersModelBackend  # pylint: disable=import-error
+from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError  # pylint: disable=import-error
+
+
+def get_edx_auth_backend():
+    """ Backend to get the default edx auth backend. """
+    return EdxRateLimitedAllowAllUsersModelBackend
+
+
+def get_edx_auth_failed():
+    """ Backend to get the AuthFailedError class. """
+    return AuthFailedError

--- a/eox_tenant/settings/aws.py
+++ b/eox_tenant/settings/aws.py
@@ -4,6 +4,8 @@ Settings for eox_tenant project meant to be called on the edx-platform/*/envs/aw
 
 from .common import *  # pylint: disable=wildcard-import
 
+EDX_AUTH_BACKEND = 'openedx.core.djangoapps.oauth_dispatch.dot_overrides.backends.EdxRateLimitedAllowAllUsersModelBackend'  # pylint: disable=line-too-long
+
 
 def plugin_settings(settings):  # pylint: disable=function-redefined
     """
@@ -31,6 +33,10 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'MICROSITES_ALL_ORGS_CACHE_KEY_TIMEOUT',
         settings.MICROSITES_ALL_ORGS_CACHE_KEY_TIMEOUT
     )
+    settings.EOX_TENANT_EDX_AUTH_BACKEND = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_TENANT_EDX_AUTH_BACKEND',
+        settings.EOX_TENANT_EDX_AUTH_BACKEND
+    )
 
     # Override the default site
     settings.SITE_ID = getattr(settings, 'ENV_TOKENS', {}).get(
@@ -43,3 +49,8 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
             'eox_tenant.middleware.AvailableScreenMiddleware',
             'eox_tenant.middleware.MicrositeCrossBrandingFilterMiddleware',
         ]
+
+        if EDX_AUTH_BACKEND in settings.AUTHENTICATION_BACKENDS:
+            settings.AUTHENTICATION_BACKENDS.remove(EDX_AUTH_BACKEND)
+
+        settings.AUTHENTICATION_BACKENDS.append('eox_tenant.auth.TenantAwareAuthBackend')

--- a/eox_tenant/settings/aws.py
+++ b/eox_tenant/settings/aws.py
@@ -5,6 +5,7 @@ Settings for eox_tenant project meant to be called on the edx-platform/*/envs/aw
 from .common import *  # pylint: disable=wildcard-import
 
 EDX_AUTH_BACKEND = 'openedx.core.djangoapps.oauth_dispatch.dot_overrides.backends.EdxRateLimitedAllowAllUsersModelBackend'  # pylint: disable=line-too-long
+EOX_TENANT_AUTH_BACKEND = 'eox_tenant.auth.TenantAwareAuthBackend'
 
 
 def plugin_settings(settings):  # pylint: disable=function-redefined
@@ -50,7 +51,4 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
             'eox_tenant.middleware.MicrositeCrossBrandingFilterMiddleware',
         ]
 
-        if EDX_AUTH_BACKEND in settings.AUTHENTICATION_BACKENDS:
-            settings.AUTHENTICATION_BACKENDS.remove(EDX_AUTH_BACKEND)
-
-        settings.AUTHENTICATION_BACKENDS.append('eox_tenant.auth.TenantAwareAuthBackend')
+        settings.AUTHENTICATION_BACKENDS = [EOX_TENANT_AUTH_BACKEND if (backend == EDX_AUTH_BACKEND) else backend for backend in settings.AUTHENTICATION_BACKENDS]  # pylint: disable=line-too-long

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -44,6 +44,7 @@ def plugin_settings(settings):
     settings.GET_BRANDING_API = 'eox_tenant.edxapp_wrapper.backends.branding_api_h_v1'
     settings.GET_CONFIGURATION_HELPERS = 'eox_tenant.edxapp_wrapper.backends.configuration_helpers_h_v1'
     settings.GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_h_v1'
+    settings.EOX_TENANT_EDX_AUTH_BACKEND = "eox_tenant.edxapp_wrapper.backends.edx_auth_i_v1"
     settings.EOX_MAX_CONFIG_OVERRIDE_SECONDS = 300
     settings.EDXMAKO_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.edxmako_h_v1'
     settings.UTILS_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.util_h_v1'

--- a/eox_tenant/test/test_auth_backend.py
+++ b/eox_tenant/test/test_auth_backend.py
@@ -1,0 +1,145 @@
+#!/usr/bin/python
+"""
+Module for Auth backend tests.
+"""
+import mock
+
+from django.contrib.auth.models import User
+from django.test import TestCase, RequestFactory, override_settings
+
+
+class TenantAwareAuthBackendTest(TestCase):
+    """
+    Test tenant aware auth backend.
+    """
+    def setUp(self):
+        """ setup """
+        self.request_factory = RequestFactory()
+
+        self.user = User.objects.create_user(
+            username='validuser',
+            password='12345',
+            email='user@valid.domain.org',
+        )
+
+        usersignup_source = mock.MagicMock()
+        usersignup_source.site = 'valid.domain.org'
+
+        usersignup_source_set = mock.MagicMock()
+        usersignup_source_set.all.return_value = [usersignup_source]
+
+        self.user.usersignupsource_set = usersignup_source_set
+
+    @override_settings(
+        REGISTRATION_EMAIL_PATTERNS_ALLOWED=None,
+        FEATURES={
+            'EDNX_ENABLE_STRICT_LOGIN': True
+        })
+    @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_failed')
+    @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_backend')
+    def test_authentication_with_signupsource(self, edx_auth_backend_mock, edx_auth_failed_mock):
+        """
+        Test if the user can authenticate in a domain where the user has signupsource
+        """
+        edx_auth_backend_mock.return_value = object
+        edx_auth_failed_mock.return_value = Exception
+
+        from eox_tenant.auth import TenantAwareAuthBackend
+
+        request = self.request_factory.get('/login')
+
+        http_host = 'valid.domain.org'
+        request.META['HTTP_HOST'] = http_host
+
+        auth_backend = TenantAwareAuthBackend()
+        auth_backend.request = request
+
+        user_can_authenticate_on_tenant = auth_backend.user_can_authenticate_on_tenant(self.user)
+
+        self.assertTrue(user_can_authenticate_on_tenant)
+
+    @override_settings(
+        REGISTRATION_EMAIL_PATTERNS_ALLOWED=None,
+        FEATURES={
+            'EDNX_ENABLE_STRICT_LOGIN': True
+        })
+    @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_failed')
+    @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_backend')
+    def test_authentication_without_signupsource(self, edx_auth_backend_mock, edx_auth_failed_mock):
+        """
+        Test if the user can authenticate in a domain where the user does not have signupsource
+        """
+        edx_auth_backend_mock.return_value = object
+        edx_auth_failed_mock.return_value = Exception
+
+        from eox_tenant.auth import TenantAwareAuthBackend
+
+        request = self.request_factory.get('/login')
+
+        http_host = 'invalid.domain.org'
+        request.META['HTTP_HOST'] = http_host
+
+        auth_backend = TenantAwareAuthBackend()
+        auth_backend.request = request
+
+        with self.assertRaises(Exception):
+            auth_backend.user_can_authenticate_on_tenant(self.user)
+
+    @override_settings(
+        REGISTRATION_EMAIL_PATTERNS_ALLOWED=[
+            "^.*@valid\\.domain\\.org$",
+        ],
+        FEATURES={
+            'EDNX_ENABLE_STRICT_LOGIN': True
+        })
+    @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_failed')
+    @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_backend')
+    def test_authentication_allowed_patterns(self, edx_auth_backend_mock, edx_auth_failed_mock):
+        """
+        Test if the user can authenticate using an email that matches with the allowed patterns
+        """
+        edx_auth_backend_mock.return_value = object
+        edx_auth_failed_mock.return_value = Exception
+
+        from eox_tenant.auth import TenantAwareAuthBackend
+
+        request = self.request_factory.get('/login')
+
+        http_host = 'valid.domain.org'
+        request.META['HTTP_HOST'] = http_host
+
+        auth_backend = TenantAwareAuthBackend()
+        auth_backend.request = request
+
+        user_can_authenticate_on_tenant = auth_backend.user_can_authenticate_on_tenant(self.user)
+
+        self.assertTrue(user_can_authenticate_on_tenant)
+
+    @override_settings(
+        REGISTRATION_EMAIL_PATTERNS_ALLOWED=[
+            "^.*@invalid\\.domain\\.org$",
+        ],
+        FEATURES={
+            'EDNX_ENABLE_STRICT_LOGIN': True
+        })
+    @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_failed')
+    @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_backend')
+    def test_authentication_without_allowed_patterns(self, edx_auth_backend_mock, edx_auth_failed_mock):
+        """
+        Test if the user can authenticate using an email that does not match with the allowed patterns
+        """
+        edx_auth_backend_mock.return_value = object
+        edx_auth_failed_mock.return_value = Exception
+
+        from eox_tenant.auth import TenantAwareAuthBackend
+
+        request = self.request_factory.get('/login')
+
+        http_host = 'valid.domain.org'
+        request.META['HTTP_HOST'] = http_host
+
+        auth_backend = TenantAwareAuthBackend()
+        auth_backend.request = request
+
+        with self.assertRaises(Exception):
+            auth_backend.user_can_authenticate_on_tenant(self.user)


### PR DESCRIPTION
This PR adds an AuthenticationBackend that prevents users that signed up on a tenant site to login in other sites.

It also adds the capability to restrict the login in a tenant site to the users with an email that matches with the REGISTRATION_EMAIL_PATTERNS_ALLOWED pattern


This changes are based on:

https://github.com/eduNEXT/edunext-platform/commits/a52131f0a631398649eeb8241e89743feb18136f/common/djangoapps/student/views