### PR TITLE
Fixing tests by moving import.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run --source="." manage.py test
-            coverage report --fail-under=51 -m
+            coverage report --fail-under=61 -m
             pycodestyle ./eox_tenant
             pylint ./eox_tenant --rcfile=./setup.cfg
 
@@ -83,6 +83,6 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run --source="." --rcfile=.coveragerc manage.py test
-            coverage report --fail-under=51 --rcfile=.coveragerc -m
+            coverage report --fail-under=61 --rcfile=.coveragerc -m
             pycodestyle ./eox_tenant
             pylint ./eox_tenant --rcfile=./setup.cfg

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ requirements: ## install environment requirements
 
 run-test: clean ## Run test suite.
 	coverage run --source="." manage.py test
-	coverage report --fail-under=40
+	coverage report --fail-under=61
 
 run-quality-test: clean ## Run quality test.
 	pycodestyle ./eox_tenant

--- a/eox_tenant/edxapp_wrapper/backends/microsite_configuration_test_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/microsite_configuration_test_v1.py
@@ -1,13 +1,12 @@
 """ Backend abstraction. """
 
-from eox_tenant.backends.base import AbstractBaseMicrositeBackend
-
 
 def get_base_microsite_backend():
     """ Backend to get BaseMicrositeBackend. """
     try:
         from microsite_configuration.backends.base import BaseMicrositeBackend as InterfaceConnectionBackend
     except ImportError:
+        from eox_tenant.backends.base import AbstractBaseMicrositeBackend
         InterfaceConnectionBackend = AbstractBaseMicrositeBackend
     return InterfaceConnectionBackend
 


### PR DESCRIPTION
Fixing tests by moving import. For some reason, the tests were failing randomly. According to my investigation we apparently inserted this problem in HA-3 (https://circleci.com/gh/eduNEXT/eox-tenant/602) and from that moment we get the tests failure sometimes in python 2.7. I ran the tests with this fix 4 consecutive times with no failures. Strange thing here: I was no able to replicate the problem running the tests in dev.

**Reason of the change**
From the traceback you can check in https://circleci.com/gh/eduNEXT/eox-tenant/602 there were nested calls of **import_module** method and that was causing a strange behavior

I also changed the Makefile to use the same fail-under value for local coverage tests

@felipemontoya 
@morenol 
@anmrdz 
@cocococosti 