### PR TITLE
Add capability to change signup source names

### DIFF
--- a/eox_tenant/edxapp_wrapper/backends/users_i_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/users_i_v1.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Users backend abstraction
+"""
+from student.models import UserSignupSource  # pylint: disable=import-error
+
+
+def get_user_signup_source():
+    """ get UserSignupSource model """
+    return UserSignupSource

--- a/eox_tenant/edxapp_wrapper/users.py
+++ b/eox_tenant/edxapp_wrapper/users.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Users public function definitions
+"""
+
+from importlib import import_module
+from django.conf import settings
+
+
+def get_user_signup_source():
+    """ Get the UserSignupSource model """
+
+    backend_function = settings.EOX_TENANT_USERS_BACKEND
+    backend = import_module(backend_function)
+
+    return backend.get_user_signup_source()

--- a/eox_tenant/settings/aws.py
+++ b/eox_tenant/settings/aws.py
@@ -38,6 +38,10 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'EOX_TENANT_EDX_AUTH_BACKEND',
         settings.EOX_TENANT_EDX_AUTH_BACKEND
     )
+    settings.EOX_TENANT_USERS_BACKEND = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_TENANT_USERS_BACKEND',
+        settings.EOX_TENANT_USERS_BACKEND
+    )
 
     # Override the default site
     settings.SITE_ID = getattr(settings, 'ENV_TOKENS', {}).get(

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -45,6 +45,7 @@ def plugin_settings(settings):
     settings.GET_CONFIGURATION_HELPERS = 'eox_tenant.edxapp_wrapper.backends.configuration_helpers_h_v1'
     settings.GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_h_v1'
     settings.EOX_TENANT_EDX_AUTH_BACKEND = "eox_tenant.edxapp_wrapper.backends.edx_auth_i_v1"
+    settings.EOX_TENANT_USERS_BACKEND = 'eox_tenant.edxapp_wrapper.backends.users_i_v1'
     settings.EOX_MAX_CONFIG_OVERRIDE_SECONDS = 300
     settings.EDXMAKO_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.edxmako_h_v1'
     settings.UTILS_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.util_h_v1'

--- a/eox_tenant/test/test_change_domain.py
+++ b/eox_tenant/test/test_change_domain.py
@@ -1,5 +1,7 @@
 """This module include a class that checks the command change_domain.py"""
 
+import mock
+
 from django.test import TestCase
 from django.contrib.sites.models import Site
 from django.core.management import call_command
@@ -19,9 +21,19 @@ class ChangeDomainTestCase(TestCase):
             domain="second.test.prod.edunext.co",
             name="second.test.prod.edunext.co")
 
-    def test_domain_can_change(self):
+        usersignup_source = mock.MagicMock()
+        usersignup_source.site = 'first.test.prod.edunext.co'
+
+        self.usersignupsource = usersignup_source
+
+    @mock.patch('eox_tenant.edxapp_wrapper.users.get_user_signup_source')
+    def test_domain_can_change(self, signupsource_mock):
         """Subdomain has been changed by the command"""
-        call_command('change_domain')
+        signupsource = mock.MagicMock()
+        signupsource.objects.all.return_value = [self.usersignupsource]
+        signupsource_mock.return_value = signupsource
+
+        call_command('change_domain', signupsources=True)
         prod = Microsite.objects.filter(  # pylint: disable=no-member
             subdomain="first.test.prod.edunext.co").first()
         stage = Microsite.objects.filter(  # pylint: disable=no-member
@@ -34,6 +46,8 @@ class ChangeDomainTestCase(TestCase):
             domain="second-test-prod-edunext-co-stage.edunext.co").first()
         self.assertIsNone(prod_site)
         self.assertIsNotNone(stage_site)
+
+        self.assertEqual(self.usersignupsource.site, 'first-test-prod-edunext-co-stage.edunext.co')
 
     def test_domain_can_change_with_point(self):
         """Subdomain has been changed by the command"""


### PR DESCRIPTION
The signupsource should be updated on stage if we want to test the TenantAwareAuthBackend 