### PR TITLE
Handle site names with the format hostname:port

### DIFF
--- a/eox_tenant/management/commands/change_domain.py
+++ b/eox_tenant/management/commands/change_domain.py
@@ -48,7 +48,10 @@ class Command(BaseCommand):
         for microsite in Microsite.objects.all():  # pylint: disable=no-member
 
             # Don't bother on changing anything if the suffix is correct
-            if microsite.subdomain.endswith(self.suffix_stage_domain):
+
+            domain = strip_port_from_host(microsite.subdomain)
+
+            if domain.endswith(self.suffix_stage_domain):
                 continue
 
             stage_domain = self.change_subdomain(microsite.subdomain)
@@ -71,7 +74,10 @@ class Command(BaseCommand):
 
         # Changing django sites objects
         for site in Site.objects.all():
-            if site.domain.endswith(self.suffix_stage_domain):
+
+            domain = strip_port_from_host(site.domain)
+
+            if domain.endswith(self.suffix_stage_domain):
                 continue
 
             stage_domain = self.change_subdomain(site.domain)
@@ -85,7 +91,10 @@ class Command(BaseCommand):
 
         if options['signupsources']:
             for signupsource in UserSignupSource.objects.all():
-                if signupsource.site.endswith(self.suffix_stage_domain):
+
+                domain = strip_port_from_host(signupsource.site)
+
+                if domain.endswith(self.suffix_stage_domain):
                     continue
 
                 stage_domain = self.change_subdomain(signupsource.site)
@@ -102,6 +111,9 @@ class Command(BaseCommand):
         my-microsite-domain-{suffix_stage_domain}
         """
         domain = strip_port_from_host(subdomain)
+        port = None
+        if ':' in subdomain:
+            port = subdomain.split(':')[1]
 
         pre_formatted = "{}-{}"
         if self.suffix_stage_domain.startswith("."):
@@ -111,6 +123,8 @@ class Command(BaseCommand):
                 domain.replace('.', '-'),
                 self.suffix_stage_domain
             )
+            if port:
+                stage_domain += ':' + port
         except TypeError as exc:
             stage_domain = ""
             message = u"Unable to define stage url for microsite {}".format(

--- a/eox_tenant/management/commands/change_domain.py
+++ b/eox_tenant/management/commands/change_domain.py
@@ -10,6 +10,7 @@ from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
 
 from eox_tenant.models import Microsite
+from eox_tenant.edxapp_wrapper.get_common_util import strip_port_from_host
 from eox_tenant.edxapp_wrapper.users import get_user_signup_source
 
 LOGGER = logging.getLogger(__name__)
@@ -100,13 +101,14 @@ class Command(BaseCommand):
         Transforming the domain to format
         my-microsite-domain-{suffix_stage_domain}
         """
+        domain = strip_port_from_host(subdomain)
 
         pre_formatted = "{}-{}"
         if self.suffix_stage_domain.startswith("."):
             pre_formatted = "{}{}"
         try:
             stage_domain = pre_formatted.format(
-                subdomain.replace('.', '-'),
+                domain.replace('.', '-'),
                 self.suffix_stage_domain
             )
         except TypeError as exc:

--- a/eox_tenant/test/test_change_domain.py
+++ b/eox_tenant/test/test_change_domain.py
@@ -22,7 +22,7 @@ class ChangeDomainTestCase(TestCase):
             name="second.test.prod.edunext.co")
 
         usersignup_source = mock.MagicMock()
-        usersignup_source.site = 'first.test.prod.edunext.co'
+        usersignup_source.site = 'first.test.prod.edunext.co:8000'
 
         self.usersignupsource = usersignup_source
 
@@ -47,7 +47,7 @@ class ChangeDomainTestCase(TestCase):
         self.assertIsNone(prod_site)
         self.assertIsNotNone(stage_site)
 
-        self.assertEqual(self.usersignupsource.site, 'first-test-prod-edunext-co-stage.edunext.co')
+        self.assertEqual(self.usersignupsource.site, 'first-test-prod-edunext-co-stage.edunext.co:8000')
 
     def test_domain_can_change_with_point(self):
         """Subdomain has been changed by the command"""


### PR DESCRIPTION
When the site name is something like: example.com:18000,

The method change_subdomain is returning  example-com:18000-stage.edunext.co instead of 

example-com-stage.edunext.co:18000 or example-com-stage.edunext.co
