### PR TITLE
Ignore case in signup source authenticaticon backend

### DIFF
--- a/eox_tenant/auth.py
+++ b/eox_tenant/auth.py
@@ -75,7 +75,7 @@ class TenantAwareAuthBackend(EdxAuthBackend):
             else:
                 AUDIT_LOG.warning(
                     u"User `%s` tried to login in site `%s`, the permission "
-                    "should have beed denied based on the signup sources.",
+                    "should have been denied based on the signup sources.",
                     loggable_id,
                     current_domain,
                 )

--- a/eox_tenant/auth.py
+++ b/eox_tenant/auth.py
@@ -52,7 +52,7 @@ class TenantAwareAuthBackend(EdxAuthBackend):
 
         is_authorized = False
         for source in sources:
-            if any(re.match(pattern + "$", source.site) for pattern in authorized_sources):
+            if any(re.match(pattern + "$", source.site, re.IGNORECASE) for pattern in authorized_sources):
                 is_authorized = True
 
         email = getattr(user, 'email', None)


### PR DESCRIPTION
This backend should ignore case. Otherwise we would not be able to authenticate in

example.com if we have a signupsource.site like 'Example.com'