### PR TITLE
Jhony/fixes eox tenant

### DIFF
--- a/eox_tenant/apps.py
+++ b/eox_tenant/apps.py
@@ -44,3 +44,10 @@ class EdunextOpenedxExtensionsTenantConfig(AppConfig):
             }
         },
     }
+
+    def ready(self):
+        """
+        Method to perform actions after apps registry is ended
+        """
+        from eox_tenant.permissions import load_permissions
+        load_permissions()

--- a/eox_tenant/auth.py
+++ b/eox_tenant/auth.py
@@ -51,6 +51,10 @@ class TenantAwareAuthBackend(EdxAuthBackend):
             return True
 
         request = theming_helpers.get_current_request()
+        # If this is not executed in the scope of a request, just allow the authentication
+        if not request:
+            return True
+
         current_domain = request.META.get("HTTP_HOST")
 
         authorized_sources = getattr(settings, 'EDNX_ACCOUNT_REGISTRATION_SOURCES', [current_domain])

--- a/eox_tenant/edxapp_wrapper/backends/theming_helpers_test_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/theming_helpers_test_v1.py
@@ -1,4 +1,5 @@
 """ Backend test abstraction. """
+from eox_tenant.test_utils import test_theming_helpers
 
 
 def get_theming_helpers():
@@ -6,5 +7,5 @@ def get_theming_helpers():
     try:
         from openedx.core.djangoapps.theming import helpers as theming_helpers
     except ImportError:
-        theming_helpers = object
+        theming_helpers = test_theming_helpers()
     return theming_helpers

--- a/eox_tenant/permissions.py
+++ b/eox_tenant/permissions.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Eox tenant permissions module
+"""
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.db.utils import ProgrammingError
+
+LOGIN_ALL_TENANTS_PERMISSION_APP_LABEL = u'auth'
+LOGIN_ALL_TENANTS_PERMISSION_CODENAME = u'can_login_all_eox_tenants'
+LOGIN_ALL_TENANTS_PERMISSION_NAME = '.'.join([
+    LOGIN_ALL_TENANTS_PERMISSION_APP_LABEL,
+    LOGIN_ALL_TENANTS_PERMISSION_CODENAME,
+])
+
+
+def load_permissions():
+    """
+    Helper method to load a custom permission on DB that will be use to control login permissions
+    on tenants.
+    """
+    if settings.EOX_TENANT_LOAD_PERMISSIONS:
+        try:
+            content_type = ContentType.objects.get_for_model(get_user_model())
+            obj, created = Permission.objects.get_or_create(  # pylint: disable=unused-variable
+                codename=LOGIN_ALL_TENANTS_PERMISSION_CODENAME,
+                name='Can login to all eox-tenant Tenants',
+                content_type=content_type,
+            )
+        except ProgrammingError:
+            # This code runs when the app is loaded, if a migration has not been done a ProgrammingError exception
+            # is raised we are bypassing those cases to let migrations run smoothly.
+            pass

--- a/eox_tenant/settings/aws.py
+++ b/eox_tenant/settings/aws.py
@@ -42,6 +42,10 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'EOX_TENANT_USERS_BACKEND',
         settings.EOX_TENANT_USERS_BACKEND
     )
+    settings.EOX_TENANT_LOAD_PERMISSIONS = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_TENANT_LOAD_PERMISSIONS',
+        settings.EOX_TENANT_LOAD_PERMISSIONS
+    )
 
     # Override the default site
     settings.SITE_ID = getattr(settings, 'ENV_TOKENS', {}).get(

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -50,6 +50,7 @@ def plugin_settings(settings):
     settings.EDXMAKO_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.edxmako_h_v1'
     settings.UTILS_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.util_h_v1'
     settings.CHANGE_DOMAIN_DEFAULT_SITE_NAME = "stage.edunext.co"
+    settings.EOX_TENANT_LOAD_PERMISSIONS = True
 
     try:
         settings.MAKO_TEMPLATE_DIRS_BASE.insert(0, path(__file__).abspath().dirname().dirname() / 'templates')  # pylint: disable=no-value-for-parameter

--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -44,3 +44,4 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     settings.FEATURES['USE_MICROSITE_AVAILABLE_SCREEN'] = False
     settings.FEATURES['USE_REDIRECTION_MIDDLEWARE'] = False
     settings.EOX_TENANT_SKIP_FILTER_FOR_TESTS = True
+    settings.EOX_TENANT_LOAD_PERMISSIONS = False

--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -1,6 +1,7 @@
 """
 Common settings for eox_tenant project.
 """
+from __future__ import absolute_import, unicode_literals
 
 from .common import *   # pylint: disable=wildcard-import
 
@@ -11,6 +12,7 @@ class SettingsClass(object):
 
 
 SETTINGS = SettingsClass()
+# This is executing the plugin_settings method imported from common module
 plugin_settings(SETTINGS)
 vars().update(SETTINGS.__dict__)
 INSTALLED_APPS = vars().get('INSTALLED_APPS', [])
@@ -32,16 +34,22 @@ TEST_DICT_OVERRIDE_TEST = {
     'key1': 'Some Value'
 }
 
+EOX_TENANT_SKIP_FILTER_FOR_TESTS = False
+EOX_TENANT_LOAD_PERMISSIONS = True
+
+FEATURES = {}
+FEATURES['USE_MICROSITE_AVAILABLE_SCREEN'] = False
+FEATURES['USE_REDIRECTION_MIDDLEWARE'] = False
+
 
 def plugin_settings(settings):  # pylint: disable=function-redefined
     """
     For the platform tests, we want everything to be disabled
     """
-
     settings.MICROSITE_BACKEND = 'eox_tenant.backends.base.BaseMicrositeBackend'
     settings.MICROSITE_TEMPLATE_BACKEND = \
         'eox_tenant.backends.base.BaseMicrositeTemplateBackend'
     settings.FEATURES['USE_MICROSITE_AVAILABLE_SCREEN'] = False
     settings.FEATURES['USE_REDIRECTION_MIDDLEWARE'] = False
-    settings.EOX_TENANT_SKIP_FILTER_FOR_TESTS = True
-    settings.EOX_TENANT_LOAD_PERMISSIONS = False
+    settings.EOX_TENANT_SKIP_FILTER_FOR_TESTS = False
+    settings.EOX_TENANT_LOAD_PERMISSIONS = True

--- a/eox_tenant/test/test_auth_backend.py
+++ b/eox_tenant/test/test_auth_backend.py
@@ -4,8 +4,13 @@ Module for Auth backend tests.
 """
 import mock
 
-from django.contrib.auth.models import User
+from django.contrib.auth.models import User, Permission
 from django.test import TestCase, RequestFactory, override_settings
+
+from eox_tenant.permissions import (
+    LOGIN_ALL_TENANTS_PERMISSION_CODENAME,
+    load_permissions
+)
 
 
 class TenantAwareAuthBackendTest(TestCase):
@@ -37,22 +42,61 @@ class TenantAwareAuthBackendTest(TestCase):
         })
     @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_failed')
     @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_backend')
-    def test_authentication_with_signupsource(self, edx_auth_backend_mock, edx_auth_failed_mock):
+    @mock.patch('eox_tenant.test_utils.test_theming_helpers.get_current_request')
+    def test_authentication_with_custom_permission(self, edx_get_current_request_mock,
+                                                   edx_auth_backend_mock, edx_auth_failed_mock):
         """
         Test if the user can authenticate in a domain where the user has signupsource
         """
         edx_auth_backend_mock.return_value = object
         edx_auth_failed_mock.return_value = Exception
 
+        request = self.request_factory.get('/login')
+
+        http_host = 'valid.domain.org'
+        request.META['HTTP_HOST'] = http_host
+
+        edx_get_current_request_mock.return_value = request
+
         from eox_tenant.auth import TenantAwareAuthBackend
+
+        auth_backend = TenantAwareAuthBackend()
+        load_permissions()
+        custom_permission = Permission.objects.get(codename=LOGIN_ALL_TENANTS_PERMISSION_CODENAME)
+        self.user.user_permissions.add(custom_permission)
+
+        user_can_authenticate_on_tenant = auth_backend.user_can_authenticate_on_tenant(self.user)
+
+        self.assertTrue(user_can_authenticate_on_tenant)
+        edx_get_current_request_mock.assert_not_called()
+        self.user.user_permissions.clear()
+
+    @override_settings(
+        REGISTRATION_EMAIL_PATTERNS_ALLOWED=None,
+        FEATURES={
+            'EDNX_ENABLE_STRICT_LOGIN': True
+        })
+    @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_failed')
+    @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_backend')
+    @mock.patch('eox_tenant.test_utils.test_theming_helpers.get_current_request')
+    def test_authentication_with_signupsource(self, edx_get_current_request_mock,
+                                              edx_auth_backend_mock, edx_auth_failed_mock):
+        """
+        Test if the user can authenticate in a domain where the user has signupsource
+        """
+        edx_auth_backend_mock.return_value = object
+        edx_auth_failed_mock.return_value = Exception
 
         request = self.request_factory.get('/login')
 
         http_host = 'valid.domain.org'
         request.META['HTTP_HOST'] = http_host
 
+        edx_get_current_request_mock.return_value = request
+
+        from eox_tenant.auth import TenantAwareAuthBackend
+
         auth_backend = TenantAwareAuthBackend()
-        auth_backend.request = request
 
         user_can_authenticate_on_tenant = auth_backend.user_can_authenticate_on_tenant(self.user)
 
@@ -65,22 +109,25 @@ class TenantAwareAuthBackendTest(TestCase):
         })
     @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_failed')
     @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_backend')
-    def test_authentication_without_signupsource(self, edx_auth_backend_mock, edx_auth_failed_mock):
+    @mock.patch('eox_tenant.test_utils.test_theming_helpers.get_current_request')
+    def test_authentication_without_signupsource(self, edx_get_current_request_mock,
+                                                 edx_auth_backend_mock, edx_auth_failed_mock):
         """
         Test if the user can authenticate in a domain where the user does not have signupsource
         """
         edx_auth_backend_mock.return_value = object
         edx_auth_failed_mock.return_value = Exception
 
-        from eox_tenant.auth import TenantAwareAuthBackend
-
         request = self.request_factory.get('/login')
 
         http_host = 'invalid.domain.org'
         request.META['HTTP_HOST'] = http_host
 
+        edx_get_current_request_mock.return_value = request
+
+        from eox_tenant.auth import TenantAwareAuthBackend
+
         auth_backend = TenantAwareAuthBackend()
-        auth_backend.request = request
 
         with self.assertRaises(Exception):
             auth_backend.user_can_authenticate_on_tenant(self.user)
@@ -94,22 +141,25 @@ class TenantAwareAuthBackendTest(TestCase):
         })
     @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_failed')
     @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_backend')
-    def test_authentication_allowed_patterns(self, edx_auth_backend_mock, edx_auth_failed_mock):
+    @mock.patch('eox_tenant.test_utils.test_theming_helpers.get_current_request')
+    def test_authentication_allowed_patterns(self, edx_get_current_request_mock,
+                                             edx_auth_backend_mock, edx_auth_failed_mock):
         """
         Test if the user can authenticate using an email that matches with the allowed patterns
         """
         edx_auth_backend_mock.return_value = object
         edx_auth_failed_mock.return_value = Exception
 
-        from eox_tenant.auth import TenantAwareAuthBackend
-
         request = self.request_factory.get('/login')
 
         http_host = 'valid.domain.org'
         request.META['HTTP_HOST'] = http_host
 
+        edx_get_current_request_mock.return_value = request
+
+        from eox_tenant.auth import TenantAwareAuthBackend
+
         auth_backend = TenantAwareAuthBackend()
-        auth_backend.request = request
 
         user_can_authenticate_on_tenant = auth_backend.user_can_authenticate_on_tenant(self.user)
 
@@ -124,22 +174,25 @@ class TenantAwareAuthBackendTest(TestCase):
         })
     @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_failed')
     @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_backend')
-    def test_authentication_without_allowed_patterns(self, edx_auth_backend_mock, edx_auth_failed_mock):
+    @mock.patch('eox_tenant.test_utils.test_theming_helpers.get_current_request')
+    def test_authentication_without_allowed_patterns(self, edx_get_current_request_mock,
+                                                     edx_auth_backend_mock, edx_auth_failed_mock):
         """
         Test if the user can authenticate using an email that does not match with the allowed patterns
         """
         edx_auth_backend_mock.return_value = object
         edx_auth_failed_mock.return_value = Exception
 
-        from eox_tenant.auth import TenantAwareAuthBackend
-
         request = self.request_factory.get('/login')
 
         http_host = 'valid.domain.org'
         request.META['HTTP_HOST'] = http_host
 
+        edx_get_current_request_mock.return_value = request
+
+        from eox_tenant.auth import TenantAwareAuthBackend
+
         auth_backend = TenantAwareAuthBackend()
-        auth_backend.request = request
 
         with self.assertRaises(Exception):
             auth_backend.user_can_authenticate_on_tenant(self.user)
@@ -151,19 +204,25 @@ class TenantAwareAuthBackendTest(TestCase):
         })
     @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_failed')
     @mock.patch('eox_tenant.edxapp_wrapper.auth.get_edx_auth_backend')
-    def test_authentication_with_signupsource_is_case_insensitive(self, edx_auth_backend_mock, edx_auth_failed_mock):
+    @mock.patch('eox_tenant.test_utils.test_theming_helpers.get_current_request')
+    def test_authentication_with_signupsource_is_case_insensitive(
+        self, edx_get_current_request_mock,
+        edx_auth_backend_mock, edx_auth_failed_mock
+    ):
         """
         Test if the backend to authenticate a user with signupsource is ignoring case
         """
         edx_auth_backend_mock.return_value = object
         edx_auth_failed_mock.return_value = Exception
 
-        from eox_tenant.auth import TenantAwareAuthBackend
-
         request = self.request_factory.get('/login')
 
         http_host = 'VALID.domain.org'
         request.META['HTTP_HOST'] = http_host
+
+        edx_get_current_request_mock.return_value = request
+
+        from eox_tenant.auth import TenantAwareAuthBackend
 
         auth_backend = TenantAwareAuthBackend()
         auth_backend.request = request

--- a/eox_tenant/test_utils.py
+++ b/eox_tenant/test_utils.py
@@ -1,0 +1,14 @@
+"""
+Utils to run tests
+"""
+
+
+class test_theming_helpers(object):
+    """
+    Test class for theming helpers
+    """
+    def get_current_request(self):
+        """
+        Test method
+        """
+        return object


### PR DESCRIPTION
Solving eox_tenant issues:

- Enabling users with specific permission to login to any tenant. The permission display name is **Can login to all eox-tenant Tenants** under the app labell **auth**

- Getting current request in custom auth backend using theming helpers method

@felipemontoya 
@morenol 
@anmrdz 
@cocococosti 