### PR TITLE
Changes to fix edxapp tests

### DIFF
--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -51,5 +51,7 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'eox_tenant.backends.base.BaseMicrositeTemplateBackend'
     settings.FEATURES['USE_MICROSITE_AVAILABLE_SCREEN'] = False
     settings.FEATURES['USE_REDIRECTION_MIDDLEWARE'] = False
-    settings.EOX_TENANT_SKIP_FILTER_FOR_TESTS = False
-    settings.EOX_TENANT_LOAD_PERMISSIONS = True
+    settings.GET_CONFIGURATION_HELPERS = 'eox_tenant.edxapp_wrapper.backends.configuration_helpers_test_v1'
+    settings.GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_test_v1'
+    settings.EOX_TENANT_SKIP_FILTER_FOR_TESTS = True
+    settings.EOX_TENANT_LOAD_PERMISSIONS = False

--- a/eox_tenant/tenant_aware_functions/enrollments.py
+++ b/eox_tenant/tenant_aware_functions/enrollments.py
@@ -7,9 +7,6 @@ from django.conf import settings
 from eox_tenant.edxapp_wrapper.configuration_helpers import get_configuration_helpers
 from eox_tenant.edxapp_wrapper.theming_helpers import get_theming_helpers
 
-theming_helpers = get_theming_helpers()
-configuration_helpers = get_configuration_helpers()
-
 
 def filter_enrollments(enrollments):
     """
@@ -17,6 +14,7 @@ def filter_enrollments(enrollments):
     do not belong to the current microsite
     """
 
+    theming_helpers = get_theming_helpers()
     test_skip = getattr(settings, "EOX_TENANT_SKIP_FILTER_FOR_TESTS", False)
     # If test setting is true, returns the same enrollments,
     # or if we do not have a microsite context, there is nothing we can do.
@@ -25,6 +23,7 @@ def filter_enrollments(enrollments):
             yield enrollment
         return
 
+    configuration_helpers = get_configuration_helpers()
     orgs_to_include = configuration_helpers.get_value('course_org_filter', None)
     orgs_to_exclude = []
 

--- a/eox_tenant/test/test_tenant_aware_functions.py
+++ b/eox_tenant/test/test_tenant_aware_functions.py
@@ -30,21 +30,23 @@ class TenantAwareFunctionsTestCase(TestCase):
         result = filter_enrollments(self.enrolls)
         self.assertEqual(len(list(result)), 4)
 
-    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.theming_helpers')
-    def test_filter_enrollments_not_request_in_microsite(self, theming_helpers_mock):
+    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.get_theming_helpers')
+    def test_filter_enrollments_not_request_in_microsite(self, get_theming_helpers_mock):
         """
         Test the case when the request is not in a microsite (filter is not applied)
         """
+        theming_helpers_mock = mock.MagicMock()
         theming_helpers_mock.is_request_in_themed_site.return_value = False
+        get_theming_helpers_mock.return_value = theming_helpers_mock
 
         result = filter_enrollments(self.enrolls)
         self.assertEqual(len(list(result)), 4)
 
         theming_helpers_mock.is_request_in_themed_site.assert_called_once()
 
-    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.theming_helpers')
-    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.configuration_helpers')
-    def test_filter_enrollments_function(self, conf_helpers_mock, theming_helpers_mock):
+    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.get_theming_helpers')
+    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.get_configuration_helpers')
+    def test_filter_enrollments_function(self, get_conf_helpers_mock, get_theming_helpers_mock):
         """
         Test that the filter works properly
         """
@@ -58,9 +60,13 @@ class TenantAwareFunctionsTestCase(TestCase):
             """
             return results_get_value.get(key, default)
 
+        conf_helpers_mock = mock.MagicMock()
+        theming_helpers_mock = mock.MagicMock()
         conf_helpers_mock.get_value.side_effect = side_effect_get_value
-
         theming_helpers_mock.is_request_in_themed_site.return_value = True
+
+        get_conf_helpers_mock.return_value = conf_helpers_mock
+        get_theming_helpers_mock.return_value = theming_helpers_mock
 
         result = filter_enrollments(self.enrolls)
         list_result = list(result)
@@ -71,9 +77,9 @@ class TenantAwareFunctionsTestCase(TestCase):
         theming_helpers_mock.is_request_in_themed_site.assert_called_once()
         conf_helpers_mock.get_value.assert_called_once()
 
-    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.theming_helpers')
-    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.configuration_helpers')
-    def test_filter_enrollments_no_org_filter(self, conf_helpers_mock, theming_helpers_mock):
+    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.get_theming_helpers')
+    @mock.patch('eox_tenant.tenant_aware_functions.enrollments.get_configuration_helpers')
+    def test_filter_enrollments_no_org_filter(self, get_conf_helpers_mock, get_theming_helpers_mock):
         """
         Test the case when the microsite does not have a course_org_filter
         """
@@ -85,11 +91,14 @@ class TenantAwareFunctionsTestCase(TestCase):
             """
             return results_get_value.get(key, default)
 
+        conf_helpers_mock = mock.MagicMock()
+        theming_helpers_mock = mock.MagicMock()
         conf_helpers_mock.get_value.side_effect = side_effect_get_value
-
         theming_helpers_mock.is_request_in_themed_site.return_value = True
-
         conf_helpers_mock.get_all_orgs.return_value = ['org1', 'org2', 'org3', 'org3']
+
+        get_conf_helpers_mock.return_value = conf_helpers_mock
+        get_theming_helpers_mock.return_value = theming_helpers_mock
 
         result = filter_enrollments(self.enrolls)
         self.assertEqual(len(list(result)), 0)


### PR DESCRIPTION
Try-catching the custom permissions loading if the django tables don't exist yet. This will fix the edxapp tests run

@felipemontoya 
@morenol 
@cocococosti 