### PR TITLE
Adding a pipeline function to associate users excluding admins

### DIFF
--- a/eox_tenant/pipeline.py
+++ b/eox_tenant/pipeline.py
@@ -1,0 +1,41 @@
+class EoxTenantAuthException(ValueError):
+    """Auth process exception."""
+
+    def __init__(self, backend, *args, **kwargs):
+        self.backend = backend
+        super(EoxTenantAuthException, self).__init__(*args, **kwargs)
+
+
+def safer_associate_by_email(backend, details, user=None, *args, **kwargs):
+    """
+    Associate current auth with a user with the same email address in the DB.
+    This pipeline entry is not 100% secure. It is better suited however for the
+    multi-tenant case so we allow it for certain tenants.
+
+    It replaces:
+    https://github.com/python-social-auth/social-core/blob/master/social_core/pipeline/social_auth.py
+    """
+    if user:
+        return None
+
+    email = details.get('email')
+    if email:
+        # Try to associate accounts registered with the same email address,
+        # only if it's a single object. AuthException is raised if multiple
+        # objects are returned.
+        users = list(backend.strategy.storage.user.get_users_by_email(email))
+        if len(users) == 0:
+            return None
+        elif len(users) > 1:
+            raise EoxTenantAuthException(
+                backend,
+                'The given email address is associated with another account'
+            )
+        else:
+            if users[0].is_staff or users[0].is_superuser:
+                EoxTenantAuthException(
+                    backend,
+                    'It is not allowed to to auto associate staff or admin users'
+                )
+            return {'user': users[0],
+                    'is_new': False}

--- a/eox_tenant/pipeline.py
+++ b/eox_tenant/pipeline.py
@@ -1,3 +1,8 @@
+"""
+The pipeline module defines functions that are used in the third party authentication flow
+"""
+
+
 class EoxTenantAuthException(ValueError):
     """Auth process exception."""
 
@@ -6,6 +11,7 @@ class EoxTenantAuthException(ValueError):
         super(EoxTenantAuthException, self).__init__(*args, **kwargs)
 
 
+# pylint: disable=unused-argument,keyword-arg-before-vararg
 def safer_associate_by_email(backend, details, user=None, *args, **kwargs):
     """
     Associate current auth with a user with the same email address in the DB.
@@ -24,7 +30,7 @@ def safer_associate_by_email(backend, details, user=None, *args, **kwargs):
         # only if it's a single object. AuthException is raised if multiple
         # objects are returned.
         users = list(backend.strategy.storage.user.get_users_by_email(email))
-        if len(users) == 0:
+        if not users:
             return None
         elif len(users) > 1:
             raise EoxTenantAuthException(
@@ -33,9 +39,9 @@ def safer_associate_by_email(backend, details, user=None, *args, **kwargs):
             )
         else:
             if users[0].is_staff or users[0].is_superuser:
-                EoxTenantAuthException(
+                raise EoxTenantAuthException(
                     backend,
-                    'It is not allowed to to auto associate staff or admin users'
+                    'It is not allowed to auto associate staff or admin users'
                 )
             return {'user': users[0],
                     'is_new': False}

--- a/eox_tenant/test/test_pipeline.py
+++ b/eox_tenant/test/test_pipeline.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+"""
+Tests for the pipeline module used in multi-tenant third party auth.
+"""
+from django.test import TestCase
+from mock import MagicMock
+
+from eox_tenant.pipeline import safer_associate_by_email, EoxTenantAuthException
+
+
+class AssociationByEmailTest(TestCase):
+    """
+    Test the custom association backend.
+    """
+    def setUp(self):
+        self.backend_mock = MagicMock()
+        self.user_mock = MagicMock()
+        self.backend_mock.strategy.storage.user.get_users_by_email.return_value = [self.user_mock]
+
+    def test_regular_user_works(self):
+        """
+        A non admin user will be assigned and returned.
+        """
+        self.user_mock.is_staff = False
+        self.user_mock.is_superuser = False
+        result = safer_associate_by_email(self.backend_mock, {'email': 'fake@example.com'})
+        self.assertEqual(self.user_mock, result['user'])
+
+    def test_staff_user_fails(self):
+        """
+        A user with a global staff flag cant be assigned.
+        """
+        self.user_mock.is_staff = True
+        self.user_mock.is_superuser = False
+        with self.assertRaises(EoxTenantAuthException):
+            safer_associate_by_email(self.backend_mock, {'email': 'fake@example.com'})
+
+    def test_superadmin_user_fails(self):
+        """
+        A superuser cant be assigned.
+        """
+        self.user_mock.is_staff = False
+        self.user_mock.is_superuser = True
+        with self.assertRaises(EoxTenantAuthException):
+            safer_associate_by_email(self.backend_mock, {'email': 'fake@example.com'})


### PR DESCRIPTION
This PR adds a function that does the same as https://github.com/python-social-auth/social-core/blob/master/social_core/pipeline/social_auth.py#L51, but protects admin users