### PR TITLE
tenancy for async tasks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run --source="." manage.py test
-            coverage report --fail-under=61 -m
+            coverage report --fail-under=71 -m
             pycodestyle ./eox_tenant
             pylint ./eox_tenant --rcfile=./setup.cfg
 
@@ -83,6 +83,6 @@ jobs:
           command: |
             . venv/bin/activate
             coverage run --source="." --rcfile=.coveragerc manage.py test
-            coverage report --fail-under=61 --rcfile=.coveragerc -m
+            coverage report --fail-under=71 --rcfile=.coveragerc -m
             pycodestyle ./eox_tenant
             pylint ./eox_tenant --rcfile=./setup.cfg

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ requirements: ## install environment requirements
 
 run-test: clean ## Run test suite.
 	coverage run --source="." manage.py test
-	coverage report --fail-under=61
+	coverage report --fail-under=71
 
 run-quality-test: clean ## Run quality test.
 	pycodestyle ./eox_tenant

--- a/eox_tenant/apps.py
+++ b/eox_tenant/apps.py
@@ -40,6 +40,14 @@ class EdunextOpenedxExtensionsTenantConfig(AppConfig):
                         'receiver_func_name': 'clear_tenant',
                         'signal_path': 'django.core.signals.got_request_exception',
                     },
+                    {
+                        'receiver_func_name': 'tenant_context_addition',
+                        'signal_path': 'celery.signals.before_task_publish',
+                    },
+                    {
+                        'receiver_func_name': 'start_async_tenant',
+                        'signal_path': 'celery.signals.task_prerun',
+                    },
                 ],
             }
         },

--- a/eox_tenant/async_utils.py
+++ b/eox_tenant/async_utils.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""
+Module that defines the class used to handle the async tasks
+"""
+
+import logging
+
+from django.conf import settings as base_settings
+from django.contrib.sites.models import Site
+
+LOG = logging.getLogger(__name__)
+
+
+class AsyncTaskHandler(object):
+    """
+    Handler used to get the tenant of an async task.
+    """
+
+    sender = None
+
+    def get_host_from_task(self, sender):
+        """
+        Method used to get the function used to get the tenant domain
+        accordingly to the type of task.
+        """
+        self.sender = sender
+        value = base_settings.EOX_TENANT_ASYNC_TASKS_HANDLER_DICT.get(sender, 'tenant_from_sync_process')
+        action = getattr(self, value)
+        return action()
+
+    def get_host_from_siteid(self):
+        """
+        Get the tenant domain name using its Site id.
+        Used in ScheduleRecurringNudge task
+        """
+        def get_host(body):
+            """
+            Get host from siteid.
+            """
+            try:
+                siteid = body.get('args')[0]
+                site = Site.objects.get(id=siteid)
+                domain = site.name
+            except (Site.DoesNotExist, KeyError, TypeError):  # pylint: disable=no-member
+                return self.tenant_from_sync_process()(body)
+            return domain
+
+        return get_host
+
+    def tenant_from_sync_process(self):
+        """
+        Used when the task is not associated to any tenant.
+        """
+        host = getattr(base_settings, 'EDNX_TENANT_DOMAIN', None)
+
+        if not host:
+            LOG.warning(
+                "Could not find the host information for eox_tenant.signals "
+                "for the task {sender}".format(sender=self.sender)
+            )
+
+        def get_host(_body):
+            """
+            Get host using default site id.
+            """
+            return host
+
+        return get_host

--- a/eox_tenant/settings/aws.py
+++ b/eox_tenant/settings/aws.py
@@ -51,7 +51,10 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'EOX_TENANT_APPEND_LMS_MIDDLEWARE_CLASSES',
         settings.EOX_TENANT_APPEND_LMS_MIDDLEWARE_CLASSES
     )
-
+    settings.EOX_TENANT_ASYNC_TASKS_HANDLER_DICT = getattr(settings, 'ENV_TOKENS', {}).get(
+        'EOX_TENANT_ASYNC_TASKS_HANDLER_DICT',
+        settings.EOX_TENANT_ASYNC_TASKS_HANDLER_DICT
+    )
     # Override the default site
     settings.SITE_ID = getattr(settings, 'ENV_TOKENS', {}).get(
         'SITE_ID',

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -53,6 +53,9 @@ def plugin_settings(settings):
     settings.EOX_TENANT_LOAD_PERMISSIONS = True
     settings.EOX_TENANT_APPEND_LMS_MIDDLEWARE_CLASSES = False
 
+    settings.EOX_TENANT_ASYNC_TASKS_HANDLER_DICT = {
+        "openedx.core.djangoapps.schedules.tasks.ScheduleRecurringNudge": "get_host_from_siteid",
+    }
     try:
         settings.MAKO_TEMPLATE_DIRS_BASE.insert(0, path(__file__).abspath().dirname().dirname() / 'templates')  # pylint: disable=no-value-for-parameter
     except AttributeError:

--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -41,6 +41,8 @@ FEATURES = {}
 FEATURES['USE_MICROSITE_AVAILABLE_SCREEN'] = False
 FEATURES['USE_REDIRECTION_MIDDLEWARE'] = False
 
+SITE_ID = 1
+
 
 def plugin_settings(settings):  # pylint: disable=function-redefined
     """

--- a/eox_tenant/test/test_async_utils.py
+++ b/eox_tenant/test/test_async_utils.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+"""
+Tests for the async_utils module.
+"""
+from django.contrib.sites.models import Site
+from django.test import TestCase
+
+from mock import patch
+
+from eox_tenant.async_utils import AsyncTaskHandler
+
+
+class AsyncTaskHandlerTests(TestCase):
+    """
+    Testing the AsyncTaskHandler class.
+    """
+
+    def setUp(self):
+        """ setup """
+        for number in range(3):
+            Site.objects.create(  # pylint: disable=no-member
+                domain="tenant{number}.com".format(number=number),
+                name="tenant{number}.com".format(number=number)
+            )
+
+    def test_get_host_from_siteid(self):
+        """
+        Test method used to get host from siteid
+        """
+        func = AsyncTaskHandler().get_host_from_siteid()
+        site = Site.objects.get(domain="tenant2.com")
+        body = {}
+        body['args'] = (site.id, None, None)
+        hostname = func(body)
+        self.assertEqual(hostname, "tenant2.com")
+
+    @patch('eox_tenant.signals._perform_reset')
+    @patch('eox_tenant.signals._update_settings')
+    def test_get_host_from_invalid_siteid(self, _update_mock, _reset_mock):
+        """
+        In case of invalid tenant the hostname should be None.
+        """
+        func = AsyncTaskHandler().get_host_from_siteid()
+        body = {}
+        body['args'] = (10, None, None)
+        hostname = func(body)
+
+        self.assertIsNone(hostname)


### PR DESCRIPTION
Handle celery signals (celery.signals.before_task_publish and celery.signals.task_prerun) to change the settings of the async process accordingly to the tenant configurations.