### PR TITLE
Make certificates tenant aware.

### DIFF
--- a/eox_tenant/edxapp_wrapper/backends/certificates_module_i_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/certificates_module_i_v1.py
@@ -1,0 +1,14 @@
+"""
+Backend Certificates file, here should be all the necessary methods,
+classes and modules from lms.djangoapss.certificates.
+"""
+from lms.djangoapps.certificates import models  # pylint: disable=import-error
+
+
+def get_certificates_models():
+    """
+    Backend function.
+
+    Return <lms.djangoapps.certificates.models>.
+    """
+    return models

--- a/eox_tenant/edxapp_wrapper/backends/certificates_module_test_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/certificates_module_test_v1.py
@@ -1,0 +1,7 @@
+""" Backend test abstraction. """
+from eox_tenant.test_utils import TestCertificatesModels
+
+
+def get_certificates_models():
+    """ Backend to get certificates models. """
+    return TestCertificatesModels()

--- a/eox_tenant/edxapp_wrapper/certificates_module.py
+++ b/eox_tenant/edxapp_wrapper/certificates_module.py
@@ -1,0 +1,10 @@
+""" Backend abstraction. """
+from importlib import import_module
+from django.conf import settings
+
+
+def get_certificates_models(*args, **kwargs):
+    """ Get the module models from <lms.djangoapps.certificates.models>. """
+    backend_function = settings.GET_CERTIFICATES_MODULE
+    backend = import_module(backend_function)
+    return backend.get_certificates_models(*args, **kwargs)

--- a/eox_tenant/settings/aws.py
+++ b/eox_tenant/settings/aws.py
@@ -51,6 +51,10 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         'USE_EOX_TENANT',
         settings.USE_EOX_TENANT
     )
+    settings.GET_CERTIFICATES_MODULE = getattr(settings, 'ENV_TOKENS', {}).get(
+        'GET_CERTIFICATES_MODULE',
+        settings.GET_CERTIFICATES_MODULE
+    )
 
     # Override the default site
     settings.SITE_ID = getattr(settings, 'ENV_TOKENS', {}).get(

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -38,6 +38,7 @@ def plugin_settings(settings):
     # Plugin settings.
     settings.EOX_TENANT_CACHE_KEY_TIMEOUT = 300
     settings.GET_BRANDING_API = 'eox_tenant.edxapp_wrapper.backends.branding_api_h_v1'
+    settings.GET_CERTIFICATES_MODULE = 'eox_tenant.edxapp_wrapper.backends.certificates_module_i_v1'
     settings.GET_SITE_CONFIGURATION_MODULE = 'eox_tenant.edxapp_wrapper.backends.site_configuration_module_i_v1'
     settings.GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_h_v1'
     settings.EOX_TENANT_EDX_AUTH_BACKEND = "eox_tenant.edxapp_wrapper.backends.edx_auth_i_v1"

--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -23,6 +23,7 @@ for app in TEST_INSTALLED_APPS:
     if app not in INSTALLED_APPS:
         INSTALLED_APPS.append(app)
 
+GET_CERTIFICATES_MODULE = 'eox_tenant.edxapp_wrapper.backends.certificates_module_test_v1'
 GET_SITE_CONFIGURATION_MODULE = 'eox_tenant.edxapp_wrapper.backends.site_configuration_module_test_v1'
 GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_test_v1'
 

--- a/eox_tenant/tenant_wise/__init__.py
+++ b/eox_tenant/tenant_wise/__init__.py
@@ -3,14 +3,14 @@ Eox Tenant Wise.
 ==================
 This module makes it possible to override the some platform Models using new proxy models.
 """
+from eox_tenant.edxapp_wrapper.certificates_module import get_certificates_models
 from eox_tenant.edxapp_wrapper.site_configuration_module import get_site_configuration_models
-from eox_tenant.tenant_wise.proxies import TenantSiteConfigProxy
-
-SiteConfigurationModels = get_site_configuration_models()
+from eox_tenant.tenant_wise.proxies import TenantSiteConfigProxy, TenantGeneratedCertificateProxy
 
 
 def load_tenant_wise_overrides():
     """
     Here are all the necessary overrides for the platform models.
     """
-    SiteConfigurationModels.SiteConfiguration = TenantSiteConfigProxy
+    get_site_configuration_models().SiteConfiguration = TenantSiteConfigProxy
+    get_certificates_models().GeneratedCertificate = TenantGeneratedCertificateProxy

--- a/eox_tenant/test_utils.py
+++ b/eox_tenant/test_utils.py
@@ -1,6 +1,34 @@
 """
 Utils to run tests
 """
+from django.db import models
+from django_fake_model import models as fake
+
+
+class CourseFakeModel(fake.FakeModel):
+    """
+    Fake Model for course.
+    """
+
+    org = models.CharField(max_length=400)
+
+
+class CertificatesFakeModel(fake.FakeModel):
+    """
+    Fake Model for certificates.
+    """
+
+    course_id = models.ForeignKey(CourseFakeModel)
+    status = models.CharField(max_length=32, default='unavailable')
+
+
+class TestCertificateStatuses(object):
+    """
+    Test Enum for certificate statuses
+    """
+    generating = 'generating'
+    audit_passing = 'audit_passing'
+    audit_notpassing = 'audit_notpassing'
 
 
 class test_theming_helpers(object):
@@ -20,3 +48,12 @@ class TestSiteConfigurationModels(object):
     """
 
     SiteConfiguration = object
+
+
+class TestCertificatesModels(object):
+    """
+    Test class for SiteConfigurationModels.
+    """
+
+    GeneratedCertificate = CertificatesFakeModel
+    CertificateStatuses = TestCertificateStatuses

--- a/requirements.in
+++ b/requirements.in
@@ -8,3 +8,4 @@ pycodestyle==2.4.0
 mock==2.0.0
 path.py==8.2.1
 django-crum==0.7.3
+django-fake-model==0.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ backports.functools-lru-cache==1.5  # via astroid, pylint
 configparser==3.5.0       # via pylint
 coverage==4.5.1
 django-crum==0.7.3
+django-fake-model==0.1.4
 django==1.11.23
 edx-opaque-keys==0.4.4
 enum34==1.1.6             # via astroid


### PR DESCRIPTION
## Description.
This allows to override the model GeneratedCertificates model, using monkey patch in order to filter the certificates by org.