### PR TITLE
Use TenantGeneratedCertificatedProxy in queue cretificates module.

### DIFF
--- a/eox_tenant/settings/aws.py
+++ b/eox_tenant/settings/aws.py
@@ -62,6 +62,11 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
         settings.SITE_ID
     )
 
+    settings.TENANT_WISE_ALLOWED_PROXIES = getattr(settings, 'ENV_TOKENS', {}).get(
+        'TENANT_WISE_ALLOWED_PROXIES',
+        settings.TENANT_WISE_ALLOWED_PROXIES
+    )
+
     if DJANGO_CURRENT_SITE_MIDDLEWARE in settings.MIDDLEWARE_CLASSES and getattr(settings, 'USE_EOX_TENANT', False):
         settings.MIDDLEWARE_CLASSES[settings.MIDDLEWARE_CLASSES.index(DJANGO_CURRENT_SITE_MIDDLEWARE)] = 'eox_tenant.middleware.CurrentSiteMiddleware'  # pylint: disable=line-too-long
 

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -54,6 +54,10 @@ def plugin_settings(settings):
     settings.EOX_TENANT_ASYNC_TASKS_HANDLER_DICT = {
         "openedx.core.djangoapps.schedules.tasks.ScheduleRecurringNudge": "get_host_from_siteid",
     }
+    settings.TENANT_WISE_ALLOWED_PROXIES = {
+        'TenantSiteConfigProxy': True,
+        'TenantGeneratedCertificateProxy': True,
+    }
     try:
         settings.MAKO_TEMPLATE_DIRS_BASE.insert(0, path(__file__).abspath().dirname().dirname() / 'templates')  # pylint: disable=no-value-for-parameter
     except AttributeError:

--- a/eox_tenant/tenant_wise/__init__.py
+++ b/eox_tenant/tenant_wise/__init__.py
@@ -3,10 +3,11 @@ Eox Tenant Wise.
 ==================
 This module makes it possible to override the some platform Models using new proxy models.
 """
+from importlib import import_module
+
+import six
 from django.conf import settings
 
-from eox_tenant.edxapp_wrapper.certificates_module import get_certificates_models
-from eox_tenant.edxapp_wrapper.site_configuration_module import get_site_configuration_models
 from eox_tenant.tenant_wise.proxies import TenantSiteConfigProxy, TenantGeneratedCertificateProxy
 
 
@@ -14,6 +15,36 @@ def load_tenant_wise_overrides():
     """
     Here are all the necessary overrides for the platform models.
     """
-    if getattr(settings, "USE_EOX_TENANT", False):
-        get_site_configuration_models().SiteConfiguration = TenantSiteConfigProxy
-        get_certificates_models().GeneratedCertificate = TenantGeneratedCertificateProxy
+    if getattr(settings, 'USE_EOX_TENANT', False):
+        allowed_proxies = getattr(settings, 'TENANT_WISE_ALLOWED_PROXIES', {})
+
+        if allowed_proxies.get('TenantSiteConfigProxy'):
+            set_as_proxy(
+                modules='openedx.core.djangoapps.site_configuration.models',
+                model='SiteConfiguration',
+                proxy=TenantSiteConfigProxy
+            )
+
+        if allowed_proxies.get('TenantGeneratedCertificateProxy'):
+            certificate_list = [
+                'lms.djangoapps.certificates.models',
+                'lms.djangoapps.certificates.queue',
+            ]
+
+            set_as_proxy(
+                modules=certificate_list,
+                model='GeneratedCertificate',
+                proxy=TenantGeneratedCertificateProxy
+            )
+
+
+def set_as_proxy(modules, model, proxy):
+    """
+    Helper to patch a loaded module with a proxy object that has all the Tenant wise properties.
+    """
+    if isinstance(modules, six.string_types):
+        modules = set([modules])
+
+    for module in modules:
+        module = import_module(module)
+        setattr(module, model, proxy)

--- a/eox_tenant/tenant_wise/context_managers.py
+++ b/eox_tenant/tenant_wise/context_managers.py
@@ -1,0 +1,24 @@
+"""
+This files should contain all the context managers for the tenant_wise module.
+"""
+import logging
+
+from contextlib import contextmanager
+
+logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def proxy_regression(module, model, regressive_model):
+    """
+    Allow to execute an operation with a different model to a given module.
+    """
+    try:
+        previous_model = getattr(module, model)
+        setattr(module, model, regressive_model)
+        yield
+    except AttributeError as error:
+        logger.error('The error %s has been generated for the module %s and model %s', error, module, model)
+        raise
+
+    setattr(module, model, previous_model)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,10 @@ configparser==3.5.0       # via pylint
 coverage==4.5.1
 django-crum==0.7.3
 django-fake-model==0.1.4
+django-mysql==2.4.1
 django==1.11.23
 edx-opaque-keys==0.4.4
 enum34==1.1.6             # via astroid
-django-mysql==2.4.1
 funcsigs==1.0.2           # via mock
 futures==3.2.0 ; python_version < "3.0"
 isort==4.3.4              # via pylint


### PR DESCRIPTION
## Description
This changes overrides the save method for GeneratedCertificate model and allows to use the TenantGeneratedCertificatedProxy in the  lms.djangoapps.certificates.queue module.