### PR TITLE
Add the capacity to read the values at the proxy

### DIFF
--- a/eox_tenant/tenant_wise/proxies.py
+++ b/eox_tenant/tenant_wise/proxies.py
@@ -72,6 +72,22 @@ class TenantSiteConfigProxy(SiteConfigurationModels.SiteConfiguration):
 
         return default
 
+    @property
+    def values(self):
+        """
+        Returns the raw values of the loaded settings.
+        """
+        if self.enabled:
+            return settings.__dict__
+        return {}
+
+    @values.setter
+    def values(self, value):
+        """
+        We ignore the setter since this is a read proxy.
+        """
+        pass
+
     def save(self, *args, **kwargs):
         """
         Don't allow to save TenantSiteConfigProxy model in database.


### PR DESCRIPTION
This PR adds a method so that the SiteConfigProxy also allows the platform code to access the `.values` property of the SiteConfig.

This is only used at helpers.has_configuration_override but impacts many areas of the code. Until the removal of microsites it was not a problem due to how the microsites backend handled the defaults, but now it is more standard