### PR TITLE
PR for fixed Dmo/added info view 

### DIFF
--- a/eox_tenant/apps.py
+++ b/eox_tenant/apps.py
@@ -12,6 +12,13 @@ class EdunextOpenedxExtensionsTenantConfig(AppConfig):
     verbose_name = "Edunext Openedx Multitenancy."
 
     plugin_app = {
+        'url_config': {
+            'lms.djangoapp': {
+                'namespace': 'eox-tenant',
+                'regex': r'^eox-tenant/',
+                'relative_path': 'urls',
+            },
+        },
         'settings_config': {
             'lms.djangoapp': {
                 'test': {'relative_path': 'settings.test'},

--- a/eox_tenant/management/commands/change_domain.py
+++ b/eox_tenant/management/commands/change_domain.py
@@ -57,7 +57,7 @@ class Command(BaseCommand):
         self.suffix_stage_ecommerce_domain = options['suffix_ecommerce_domain']
 
         # Changing microsites objects
-        for microsite in Microsite.objects.all():  # pylint: disable=no-member
+        for microsite in Microsite.objects.all():
 
             stage_domain = self.change_subdomain(microsite.subdomain)
 

--- a/eox_tenant/management/commands/edit_tenant_values.py
+++ b/eox_tenant/management/commands/edit_tenant_values.py
@@ -93,7 +93,7 @@ class Command(BaseCommand):
             LOGGER.info('Options recognized from the command call')
             LOGGER.info(options)
 
-        query = Microsite.objects.all()  # pylint: disable=no-member
+        query = Microsite.objects.all()
 
         if options['pattern']:
             query = query.filter(subdomain__icontains=options['pattern'][0])

--- a/eox_tenant/models.py
+++ b/eox_tenant/models.py
@@ -131,7 +131,7 @@ class Microsite(models.Model):
 
         # remove any port number from the hostname
         domain = domain.split(':')[0]
-        microsites = cls.objects.filter(subdomain=domain)  # pylint: disable=no-member
+        microsites = cls.objects.filter(subdomain=domain)
 
         return microsites[0] if microsites else None
 
@@ -146,7 +146,7 @@ class Microsite(models.Model):
         Returns:
             The value for the given key and org.
         """
-        results = cls.objects.filter(  # pylint: disable=no-member
+        results = cls.objects.filter(
             values__course_org_filter__contains=org
         ).values_list("values", flat=True)
 

--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -44,6 +44,8 @@ USE_EOX_TENANT = True
 
 SITE_ID = 1
 
+ROOT_URLCONF = 'eox_tenant.urls'
+
 
 def plugin_settings(settings):  # pylint: disable=function-redefined
     """

--- a/eox_tenant/tenant_wise/proxies.py
+++ b/eox_tenant/tenant_wise/proxies.py
@@ -110,7 +110,7 @@ class TenantSiteConfigProxy(SiteConfigurationModels.SiteConfiguration):
 
         org_filter_set = set()
         tenant_config = TenantConfig.objects.values_list("lms_configs", flat=True)
-        microsite_config = Microsite.objects.values_list("values", flat=True)  # pylint: disable=no-member
+        microsite_config = Microsite.objects.values_list("values", flat=True)
 
         for config in chain(tenant_config, microsite_config):
             try:
@@ -200,7 +200,7 @@ class TenantSiteConfigProxy(SiteConfigurationModels.SiteConfiguration):
 
         result = None
         tenant_config = TenantConfig.objects.values_list("lms_configs", flat=True)
-        microsite_config = Microsite.objects.values_list("values", flat=True)  # pylint: disable=no-member
+        microsite_config = Microsite.objects.values_list("values", flat=True)
 
         for config in chain(tenant_config, microsite_config):
             try:
@@ -244,12 +244,12 @@ class TenantSiteConfigProxy(SiteConfigurationModels.SiteConfiguration):
                 lms_configs__has_key=u"course_org_filter",
             ).values_list("lms_configs", flat=True)
 
-            microsite_config = Microsite.objects.filter(  # pylint: disable=no-member
+            microsite_config = Microsite.objects.filter(
                 values__has_key=u"course_org_filter",
             ).values_list("values", flat=True)
         except FieldError:
             tenant_config = TenantConfig.objects.values_list("lms_configs")
-            microsite_config = Microsite.objects.values_list("values")  # pylint: disable=no-member
+            microsite_config = Microsite.objects.values_list("values")
 
         for config in chain(microsite_config, tenant_config):
             try:

--- a/eox_tenant/test/test_async_utils.py
+++ b/eox_tenant/test/test_async_utils.py
@@ -18,7 +18,7 @@ class AsyncTaskHandlerTests(TestCase):
     def setUp(self):
         """ setup """
         for number in range(3):
-            Site.objects.create(  # pylint: disable=no-member
+            Site.objects.create(
                 domain="tenant{number}.com".format(number=number),
                 name="tenant{number}.com".format(number=number)
             )

--- a/eox_tenant/test/test_change_domain.py
+++ b/eox_tenant/test/test_change_domain.py
@@ -14,9 +14,9 @@ class ChangeDomainTestCase(TestCase):
 
     def setUp(self):
         """This method creates Microsite objects in database"""
-        Microsite.objects.create(  # pylint: disable=no-member
+        Microsite.objects.create(
             subdomain="first.test.prod.edunext.co")
-        Site.objects.create(  # pylint: disable=no-member
+        Site.objects.create(
             domain="second.test.prod.edunext.co",
             name="second.test.prod.edunext.co")
 
@@ -33,15 +33,15 @@ class ChangeDomainTestCase(TestCase):
         signupsource_mock.return_value = signupsource
 
         call_command('change_domain', signupsources=True)
-        prod = Microsite.objects.filter(  # pylint: disable=no-member
+        prod = Microsite.objects.filter(
             subdomain="first.test.prod.edunext.co").first()
-        stage = Microsite.objects.filter(  # pylint: disable=no-member
+        stage = Microsite.objects.filter(
             subdomain="first-test-prod-edunext-co-stage.edunext.co").first()
         self.assertIsNone(prod)
         self.assertIsNotNone(stage)
-        prod_site = Site.objects.filter(  # pylint: disable=no-member
+        prod_site = Site.objects.filter(
             domain="second.test.prod.edunext.co").first()
-        stage_site = Site.objects.filter(  # pylint: disable=no-member
+        stage_site = Site.objects.filter(
             domain="second-test-prod-edunext-co-stage.edunext.co").first()
         self.assertIsNone(prod_site)
         self.assertIsNotNone(stage_site)
@@ -51,15 +51,15 @@ class ChangeDomainTestCase(TestCase):
     def test_domain_can_change_with_point(self):
         """Subdomain has been changed by the command"""
         call_command('change_domain', suffix_domain=".stage.edunext.co")
-        prod = Microsite.objects.filter(  # pylint: disable=no-member
+        prod = Microsite.objects.filter(
             subdomain="first.test.prod.edunext.co").first()
-        stage = Microsite.objects.filter(  # pylint: disable=no-member
+        stage = Microsite.objects.filter(
             subdomain="first-test-prod-edunext-co.stage.edunext.co").first()
         self.assertIsNone(prod)
         self.assertIsNotNone(stage)
-        prod_site = Site.objects.filter(  # pylint: disable=no-member
+        prod_site = Site.objects.filter(
             domain="second.test.prod.edunext.co").first()
-        stage_site = Site.objects.filter(  # pylint: disable=no-member
+        stage_site = Site.objects.filter(
             domain="second-test-prod-edunext-co.stage.edunext.co").first()
         self.assertIsNone(prod_site)
         self.assertIsNotNone(stage_site)
@@ -70,7 +70,7 @@ class ChangeDomainTestCase(TestCase):
             "ECOMMERCE_PUBLIC_URL_ROOT": "https://ecommerce.url/",
             "ECOMMERCE_API_URL": "https://ecommerce.url/api/v1/",
         }
-        prod = Microsite.objects.filter(  # pylint: disable=no-member
+        prod = Microsite.objects.filter(
             subdomain="first.test.prod.edunext.co").first()
         prod.values = values
         prod.save()
@@ -79,7 +79,7 @@ class ChangeDomainTestCase(TestCase):
             suffix_domain=".stage.edunext.co",
             suffix_ecommerce_domain=".stage-compl1.edunext.co"
         )
-        stage = Microsite.objects.filter(  # pylint: disable=no-member
+        stage = Microsite.objects.filter(
             subdomain="first-test-prod-edunext-co.stage.edunext.co").first()
         ecommerce_public_url_root = stage.values['ECOMMERCE_PUBLIC_URL_ROOT']
         ecommerce_api_url = stage.values['ECOMMERCE_API_URL']

--- a/eox_tenant/test/test_edit_tenant_values.py
+++ b/eox_tenant/test/test_edit_tenant_values.py
@@ -13,7 +13,7 @@ class EditTenantValuesTestCase(TestCase):
 
     def setUp(self):
         """This method creates Microsite objects in database"""
-        Microsite.objects.create(  # pylint: disable=no-member
+        Microsite.objects.create(
             key="test",
             subdomain="first.test.prod.edunext.co",
             values={
@@ -36,7 +36,7 @@ class EditTenantValuesTestCase(TestCase):
     def test_command_exec_confirmation_add(self, _):
         """Tests that we can add a new key"""
         call_command('edit_tenant_values', '--add', 'NEW_KEY', 'NEW_VALUE')
-        tenant = Microsite.objects.get(key='test')  # pylint: disable=no-member
+        tenant = Microsite.objects.get(key='test')
         self.assertIn('NEW_KEY', tenant.values)
         self.assertEqual('NEW_VALUE', tenant.values.get('NEW_KEY'))
 
@@ -44,7 +44,7 @@ class EditTenantValuesTestCase(TestCase):
     def test_command_exec_confirmation_add_nested(self, _):
         """Tests that we can add a new nested key"""
         call_command('edit_tenant_values', '--add', 'NEW_KEY.nested', 'NEW_VALUE')
-        tenant = Microsite.objects.get(key='test')  # pylint: disable=no-member
+        tenant = Microsite.objects.get(key='test')
         self.assertIn('nested', tenant.values.get('NEW_KEY'))
         self.assertEqual('NEW_VALUE', tenant.values.get('NEW_KEY').get('nested'))
 
@@ -52,21 +52,20 @@ class EditTenantValuesTestCase(TestCase):
     def test_command_exec_confirmation_delete(self, _):
         """Tests that we can remove a key"""
         call_command('edit_tenant_values', '--delete', 'KEY')
-        tenant = Microsite.objects.get(key='test')  # pylint: disable=no-member
+        tenant = Microsite.objects.get(key='test')
         self.assertNotIn('KEY', tenant.values)
 
     @patch('eox_tenant.management.commands.edit_tenant_values.input', return_value='y')
     def test_command_exec_confirmation_delete_chain(self, _):
         """Tests that we can remove a nested key"""
         call_command('edit_tenant_values', '--delete', 'NESTED_KEY.key')
-        tenant = Microsite.objects.get(key='test')  # pylint: disable=no-member
+        tenant = Microsite.objects.get(key='test')
         self.assertIn('NESTED_KEY', tenant.values)
         self.assertNotIn('key', tenant.values.get('NESTED_KEY'))
 
     @patch('eox_tenant.management.commands.edit_tenant_values.input', return_value='y')
     def test_command_exec_confirmation_pattern(self, _):
         """Tests that we can affect only the sites defined by a pattern in their subdomain"""
-        # pylint: disable=no-member
         Microsite.objects.create(
             key="test2",
             subdomain="second.test.prod.edunext.co",

--- a/eox_tenant/test/test_receivers_helpers.py
+++ b/eox_tenant/test/test_receivers_helpers.py
@@ -22,7 +22,7 @@ class ReceiversHelpersTests(TestCase):
         """
         Setup database.
         """
-        Microsite.objects.create(  # pylint: disable=no-member
+        Microsite.objects.create(
             subdomain="first.test.prod.edunext",
             key="test_fake_key",
             values={

--- a/eox_tenant/test/test_signals.py
+++ b/eox_tenant/test/test_signals.py
@@ -291,7 +291,7 @@ class CeleryReceiverCLISyncTests(TestCase):
     def setUp(self):
         """ setup """
         for number in range(3):
-            Site.objects.create(  # pylint: disable=no-member
+            Site.objects.create(
                 domain="tenant{number}.com".format(number=number),
                 name="tenant{number}.com".format(number=number)
             )
@@ -332,7 +332,7 @@ class CeleryReceiverSyncTests(TestCase):
     def setUp(self):
         """ setup """
         for number in range(3):
-            Site.objects.create(  # pylint: disable=no-member
+            Site.objects.create(
                 domain="tenant{number}.com".format(number=number),
                 name="tenant{number}.com".format(number=number)
             )

--- a/eox_tenant/test/test_tenant_wise.py
+++ b/eox_tenant/test/test_tenant_wise.py
@@ -19,7 +19,7 @@ class TenantSiteConfigProxyTest(TestCase):
         """
         This method creates Microsite, TenantConfig and Route objects and in database.
         """
-        Microsite.objects.create(  # pylint: disable=no-member
+        Microsite.objects.create(
             subdomain="first.test.prod.edunext",
             key="test_fake_key",
             values={
@@ -28,7 +28,7 @@ class TenantSiteConfigProxyTest(TestCase):
             }
         )
 
-        Microsite.objects.create(  # pylint: disable=no-member
+        Microsite.objects.create(
             subdomain="second.test.prod.edunext",
             values={
                 "course_org_filter": ["test2-org", "test3-org"],
@@ -131,17 +131,17 @@ class TenantGeneratedCertificateProxyTest(TestCase):
         This verifies that all the returned objects are filtered by org.
         """
         TenantGeneratedCertificateProxy.objects.create(
-            course_id="course-v1:test-org+CS102+2019_T2",  # pylint: disable=no-member
+            course_id="course-v1:test-org+CS102+2019_T2",
             status=TestCertificateStatuses.generating
         )
 
         TenantGeneratedCertificateProxy.objects.create(
-            course_id="course-v1:test-org1+CS102+2019_T2",  # pylint: disable=no-member
+            course_id="course-v1:test-org1+CS102+2019_T2",
             status=TestCertificateStatuses.audit_notpassing
         )
 
         TenantGeneratedCertificateProxy.objects.create(
-            course_id="course-v1:test-org+CS102+2019_T2",  # pylint: disable=no-member
+            course_id="course-v1:test-org+CS102+2019_T2",
             status=TestCertificateStatuses.audit_passing
         )
 

--- a/eox_tenant/test/test_views.py
+++ b/eox_tenant/test/test_views.py
@@ -1,0 +1,45 @@
+"""
+Test views file.
+"""
+from os.path import dirname
+from subprocess import check_output, CalledProcessError
+
+from django.test import TestCase
+from django.urls import reverse
+
+
+class EOXInfoTestCase(TestCase):
+    """
+    Test for eox-info view.
+    """
+
+    def test_view_info_accesible(self):
+        """
+        Should get a successful answer
+        """
+        with self.settings(ALLOWED_HOSTS=['testserver']):
+            response = self.client.get(reverse('eox-info'), HTTP_HOST='testserver')
+            self.assertEqual(response.status_code, 200)
+
+    def test_view_info_response_data(self):
+        """
+        Check the content of the response.
+        """
+        with self.settings(ALLOWED_HOSTS=['testserver']):
+            response = self.client.get(reverse('eox-info'), HTTP_HOST='testserver')
+            content = response.json()
+
+            working_dir = dirname(__file__)
+            version = check_output(["git", "describe", "--tags", "--abbrev=0"], cwd=working_dir)
+            version = version.decode().replace('\n', '')[1:]
+            name = 'eox-tenant'
+            commit_id = check_output(["git", "rev-parse", "HEAD"], cwd=working_dir)
+            commit_id = commit_id.decode().replace('\n', '')
+
+            self.assertEqual(version, content['version'])
+            self.assertEqual(name, content['name'])
+            self.assertEqual(commit_id, content['git'])
+            self.assertEqual(response.status_code, 200)
+
+        with self.assertRaises(CalledProcessError):
+            commit_id = check_output(["git", "rev", "HEAD"], cwd=working_dir)

--- a/eox_tenant/urls.py
+++ b/eox_tenant/urls.py
@@ -1,0 +1,9 @@
+"""eox-tenant urls"""
+
+from django.conf.urls import url
+from eox_tenant import views
+
+
+urlpatterns = [
+    url(r'^eox-info$', views.info_view, name='eox-info'),
+]

--- a/eox_tenant/views.py
+++ b/eox_tenant/views.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""The generic views for the eox-tenant plugin project"""
+
+from __future__ import unicode_literals
+
+from os.path import dirname, realpath
+from subprocess import check_output, CalledProcessError
+
+from django.http import JsonResponse
+
+import eox_tenant
+
+
+def info_view(request):  # pylint: disable=unused-argument
+    """
+    Basic view to show the working version and the exact git commit of the
+    installed app.
+    """
+    try:
+        working_dir = dirname(realpath(__file__))
+        git_data = check_output(["git", "rev-parse", "HEAD"], cwd=working_dir)
+    except CalledProcessError:
+        git_data = ""
+
+    response_data = {
+        "version": eox_tenant.__version__,
+        "name": "eox-tenant",
+        "git": git_data.decode().rstrip('\r\n'),
+    }
+    return JsonResponse(response_data)


### PR DESCRIPTION
This PR fixes:

**1.** The following errors for test-3.6 in circle CI:

![Screenshot from 2020-05-12 10-25-16](https://user-images.githubusercontent.com/64440265/81704428-c528fb00-943b-11ea-8fab-257b7bd35ccd.png)

I fixed them adding  _testservers_ to the allowed hosts doing the following:

with self.settings(ALLOWED_HOSTS=['testserver']):
                  response = self.client.get(reverse('eox-info'), HTTP_HOST='testserver')

In the following file: eox_tenant/test/test_views.py

I'm not sure why this happened using python 3.6. If you know, please comment on this post.

**2.** After fixing 1, another error came up in the same file:

eox_tenant/test/test_views.py", line 34, in test_view_info_response_data
    version = version.replace('\n', '')[1:]
TypeError: a bytes-like object is required, not 'str'

What I did to fix it was adding the _decode_ method to the _check_output_ outputs in eox_tenant/test/test_views.py and eox_tenant/views.py. 

The main problem was that the output of check_output was in bytes and it was being treated as a string. 

**3.** After fixing 1 and 2, I fixed the quality errors, most of them were _Useless suppression of 'no-member' (useless-suppression)_

If you have any suggestions to improve this PR, please let me know!

@felipemontoya 
@morenol 