### PR TITLE
Added setup for isort in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -294,3 +294,9 @@ disable =
 	old-style-class,
 	inconsistent-return-statements
 
+[isort]
+known_first_party = eox_tenant
+include_trailing_comma = True
+indent = '    '
+line_length = 120
+multi_line_output = 3


### PR DESCRIPTION
This PR adds settings in setup.cfg for using _isort_ in the project, this allows ordering the imports as follows:

1. Future imports
2. Python Standard Libraries
3. Django core
4. Third-party libraries (related or not to Django)
5. First party libraries (that is, our project’s imports)
6. Local imports

I used this configuration to sort all eox_tenant files, then I ran make run-quality-test and got 10/10.

Also, what do you think about the settings?

See references:
[Orginize imports reference](https://simpleisbetterthancomplex.com/packages/2016/10/08/isort.html)
[Isort settings](https://github.com/timothycrosley/isort/wiki/isort-Settings)
[Section settings](https://github.com/timothycrosley/isort#custom-sections-and-ordering)

@felipemontoya 
@morenol 
@andrey-canon 