### PR TITLE
[WIP] Adding custom exceptions/error logging

### DIFF
--- a/eox_tenant/auth.py
+++ b/eox_tenant/auth.py
@@ -21,6 +21,13 @@ UserModel = get_user_model()
 theming_helpers = get_theming_helpers()
 
 
+class EoxTenantAuthFailedError(AuthFailedError):
+    """Exception raised for errors in Authentication.
+        Inherits from AuthFailedError defined by EdxApp
+    """
+    pass
+
+
 class TenantAwareAuthBackend(EdxAuthBackend):
     """
     Authentication Backend class which will check if the user has a signupsource in the requested site.
@@ -84,7 +91,7 @@ class TenantAwareAuthBackend(EdxAuthBackend):
                     loggable_id,
                     current_domain,
                 )
-                raise AuthFailedError(_('User not authorized to perform this action'))
+                raise EoxTenantAuthFailedError(_('User not authorized to perform this action'))
             else:
                 AUDIT_LOG.warning(
                     u"User `%s` tried to login in site `%s`, the permission "

--- a/eox_tenant/tenant_wise/context_managers.py
+++ b/eox_tenant/tenant_wise/context_managers.py
@@ -18,7 +18,12 @@ def proxy_regression(module, model, regressive_model):
         setattr(module, model, regressive_model)
         yield
     except AttributeError as error:
-        logger.error('The error %s has been generated for the module %s and model %s', error, module, model)
+        logger.error(
+            "EoxTenantAttributeError | The error %s has been generated for the module %s and model %s",
+            error,
+            module,
+            model,
+        )
         raise
 
     setattr(module, model, previous_model)

--- a/eox_tenant/tenant_wise/proxies.py
+++ b/eox_tenant/tenant_wise/proxies.py
@@ -71,7 +71,9 @@ class TenantSiteConfigProxy(SiteConfigurationModels.SiteConfiguration):
         try:
             return getattr(settings, name, default)
         except AttributeError as error:
-            logger.exception("Invalid data at the TenantConfigProxy get_value. \n [%s]", error)
+            logger.exception(
+                "EoxTenantAttributeError | Invalid data at the TenantConfigProxy get_value. \n [%s]",
+                error)
 
         return default
 


### PR DESCRIPTION
This PR adds custom error logging so it is easier finding eox-tenant errors in Sentry.

For now, these are the changes I've made:

- Added prefix to log.error: every log.error message has an _EoxTenantError_ prefix where _error_ is the error logged. For example:

`logger.error('EoxTenantAttributeError | The error %s has been generated for the module %s and model %s', error, module, model)`

- custom exceptions: added custom auth exception for AuthFailedException in auth.py file. This helps to find the exception in sentry.

What do you think about this changes? 

The questions (and some solutions and notes) we've come up with until now are:

1. What can we do with the warnings that we want to log in sentry? It's important to know that sentry only logs errors and raised exceptions due to its configuration in Eox-Core.

- Sentry has a function called capture_message that logs messages with an error level in sentry, I think this logged message does not appear in the server logs. We can use this function to log the warnings we want in sentry without producing noise in the other logs. 
@jfavellar90 came up with an idea to make a notify file where we decide how to log the warnings 

- We could also change the error level from a warning to an error. The problem is that we would be changing the level only to be able to log the message and that could cause confusion.

2. What can we do with all the built-in python/django exceptions? Can we write for every, for example, RuntimeError an EoxTenantRuntimeError? 

- If we do this, we could make a custom exceptions file where we define all the custom exceptions we need. But is this necessary?

What do you think?

@jfavellar90 
@morenol 
@felipemontoya 
