### PR TITLE
FIXED isort setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -295,6 +295,7 @@ disable =
 	inconsistent-return-statements
 
 [isort]
+default_section = THIRDPARTY
 known_first_party = eox_tenant
 include_trailing_comma = True
 indent = '    '


### PR DESCRIPTION
This PR adds a new line in the isort setup so the imports are ordered as follows:

Future imports
Python Standard Libraries
Django core
Third party libraries (related or not to Django)
First party libraries (that is, our project’s imports)
Local imports

The line added is:
`default_section = THIRDPARTY`

@morenol 
@andrey-canon 