### PR TITLE
Fixed error in migrations by checking environment

### DIFF
--- a/eox_tenant/constants.py
+++ b/eox_tenant/constants.py
@@ -1,0 +1,4 @@
+"""Module where eox-tenant constants are defined."""
+from django.conf import settings
+
+LMS_ENVIRONMENT = getattr(settings, "SERVICE_VARIANT", None) == "lms"

--- a/eox_tenant/edxapp_wrapper/backends/certificates_module_i_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/certificates_module_i_v1.py
@@ -5,6 +5,7 @@ classes and modules from lms.djangoapss.certificates.
 from django.conf import settings
 from lms.djangoapps.certificates import models  # pylint: disable=import-error
 
+from eox_tenant.constants import LMS_ENVIRONMENT
 from eox_tenant.test_utils import TestCertificatesModels
 
 
@@ -19,4 +20,4 @@ def get_certificates_models():
     # when we are running the platform test, in order to avoid django migration errors.
     # USE_EOX_TENANT is set to False by default, which allows to run the platform tests with its normal behavior,
     # and the plugin tests are run with a different backend.
-    return models if getattr(settings, 'USE_EOX_TENANT', False) else TestCertificatesModels()
+    return models if getattr(settings, 'USE_EOX_TENANT', False) and LMS_ENVIRONMENT else TestCertificatesModels()

--- a/eox_tenant/tenant_wise/__init__.py
+++ b/eox_tenant/tenant_wise/__init__.py
@@ -9,6 +9,7 @@ from importlib import import_module
 import six
 from django.conf import settings
 
+from eox_tenant.constants import LMS_ENVIRONMENT
 from eox_tenant.tenant_wise.proxies import TenantGeneratedCertificateProxy, TenantSiteConfigProxy
 
 
@@ -26,7 +27,7 @@ def load_tenant_wise_overrides():
                 proxy=TenantSiteConfigProxy
             )
 
-        if allowed_proxies.get('TenantGeneratedCertificateProxy'):
+        if allowed_proxies.get('TenantGeneratedCertificateProxy') and LMS_ENVIRONMENT:
             set_package_members_as_proxy(
                 package_name='lms.djangoapps.certificates',
                 model='GeneratedCertificate',


### PR DESCRIPTION
The error was the following:
```
Operations to perform:
  Apply all migrations: admin, api_admin, assessment, auth, block_structure, bookmarks, catalog, ccxcon, celery_utils, completion, consent, content_type_gating, contentserver, contentstore, contenttypes, course_action_state, course_creators, course_duration_limits, course_groups, course_modes, course_overviews, courseware, crawlers, credit, dark_lang, database_fixups, degreed, django_comment_common, django_notify, django_openid_auth, djcelery, edx_oauth2_provider, edx_proctoring, edxval, embargo, enterprise, entitlements, eox_core, eox_tenant, experiments, external_auth, integrated_channel, microsite_configuration, milestones, oauth2, oauth2_provider, oauth_dispatch, oauth_provider, organizations, problem_builder, redirects, sap_success_factors, schedules, self_paced, sessions, site_configuration, sites, static_replace, student, submissions, survey, tagging, theming, track, user_api, user_authn, user_tasks, verified_track_content, verify_student, video_config, video_pipeline, waffle, waffle_utils, wiki, workflow, xapi, xblock_config, xblock_django
Running migrations:
  No migrations to apply.
Traceback (most recent call last):
  File "manage.py", line 123, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/management/commands/migrate.py", line 186, in handle
    changes = autodetector.changes(graph=executor.loader.graph)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/migrations/autodetector.py", line 47, in changes
    changes = self._detect_changes(convert_apps, graph)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/migrations/autodetector.py", line 134, in _detect_changes
    self.new_apps = self.to_state.apps
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/functional.py", line 35, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/migrations/state.py", line 218, in apps
    return StateApps(self.real_apps, self.models)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/migrations/state.py", line 288, in __init__
    self.render_multiple(list(models.values()) + self.real_models)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/migrations/state.py", line 331, in render_multiple
    "for more" % (new_unrendered_models, get_docs_version())
django.db.migrations.exceptions.InvalidBasesError: Cannot resolve bases for [<ModelState: 'eox_tenant.TenantGeneratedCertificateProxy'>]
This can happen if you are inheriting models from an app with migrations (e.g. contrib.auth)
 in an app with no migrations; see https://docs.djangoproject.com/en/1.11/topics/migrations/#dependencies for more
```
 Now, the following condition is checked `settings.SERVICE_VARIANT == "lms"` so the `manage cms migrate` won't crash due missing migrations for the base model generatedcertificates