### PR TITLE
[JUNIPER LD-9]Override SiteConfiguration in contenstore.utils

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+Added
+_____
+
+* Override contentstore SiteConfiguration.
+
+
 [3.2.0] - 2020-09-28
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/eox_tenant/tenant_wise/__init__.py
+++ b/eox_tenant/tenant_wise/__init__.py
@@ -21,8 +21,13 @@ def load_tenant_wise_overrides():
         allowed_proxies = getattr(settings, 'TENANT_WISE_ALLOWED_PROXIES', {})
 
         if allowed_proxies.get('TenantSiteConfigProxy'):
+            modules = ['openedx.core.djangoapps.site_configuration.models']
+
+            if not LMS_ENVIRONMENT:
+                modules.append('contentstore.utils')
+
             set_as_proxy(
-                modules='openedx.core.djangoapps.site_configuration.models',
+                modules=modules,
                 model='SiteConfiguration',
                 proxy=TenantSiteConfigProxy
             )


### PR DESCRIPTION
## Description
This is part of LD-9, this change will avoid to include configuration_helpers in the contentstore.utils file