### PR TITLE
Add pypi to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,15 @@ workflows:
             exclude:
               - python_version: "2.7"
                 django_version: "django22"
+      - pypi:
+          requires:
+            - test
+          filters:
+            tags:
+              only: /v?[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/
+
 jobs:
   test:
     parameters:


### PR DESCRIPTION
## Description
By mistake the pypi section was removed in this pr https://github.com/eduNEXT/eox-tenant/pull/106/files, this reverts these changes.