### PR TITLE
Fix proxy compatibility issue in juniper

### DIFF
--- a/eox_tenant/tenant_wise/proxies.py
+++ b/eox_tenant/tenant_wise/proxies.py
@@ -89,6 +89,19 @@ class TenantSiteConfigProxy(SiteConfigurationModels.SiteConfiguration):
         """
         pass
 
+    @property
+    def site_values(self):
+        """
+        Returns the raw values of the loaded settings. This version works with juniper releases.
+        """
+        return self.values
+
+    @site_values.setter
+    def site_values(self, value):
+        """
+        We ignore the setter since this is a read proxy. This version works with juniper releases.
+        """
+
     def save(self, *args, **kwargs):
         """
         Don't allow to save TenantSiteConfigProxy model in database.


### PR DESCRIPTION
This PR adds site_values as property to SiteConfiguration proxy, this is done due to this change: https://github.com/edx/edx-platform/pull/23306/files

Thank you for the help! @andrey-canon 