### PR TITLE
Fix error 500 when entering invalid JSON

### DIFF
--- a/eox_tenant/widgets.py
+++ b/eox_tenant/widgets.py
@@ -17,11 +17,10 @@ class JsonWidget(Widget):
         """
         Add indent to JSONField.
         """
-        value = json.loads(value) if isinstance(value, six.string_types) else value
-
         try:
+            value = json.loads(value) if isinstance(value, six.string_types) else value
             value = json.dumps(value, indent=4, sort_keys=True)
-        except ValueError:
+        except (ValueError, json.decoder.JSONDecodeError):  # pylint: disable=no-member
             pass
         return {'widget': {
             'name': name,


### PR DESCRIPTION
This PR fixes the following error when entering invalid JSON values in TenantConfig admin:

![Screenshot from 2020-11-20 09-09-39](https://user-images.githubusercontent.com/64440265/99803805-6b9f3880-2b10-11eb-9177-7cbb7494100b.png)

Instead should be:
![Screenshot from 2020-11-20 09-08-08](https://user-images.githubusercontent.com/64440265/99804230-0dbf2080-2b11-11eb-8880-752066ad9e6f.png)
