### PR TITLE
Fix error 500 in eox-info view

### DIFF
--- a/eox_tenant/views.py
+++ b/eox_tenant/views.py
@@ -19,12 +19,14 @@ def info_view(request):  # pylint: disable=unused-argument
     try:
         working_dir = dirname(realpath(__file__))
         git_data = check_output(["git", "rev-parse", "HEAD"], cwd=working_dir)
+        git_data = git_data.decode().rstrip('\r\n')
     except CalledProcessError:
         git_data = ""
 
-    response_data = {
-        "version": eox_tenant.__version__,
-        "name": "eox-tenant",
-        "git": git_data.decode().rstrip('\r\n'),
-    }
-    return JsonResponse(response_data)
+    return JsonResponse(
+        {
+            "version": eox_tenant.__version__,
+            "name": "eox-tenant",
+            "git": git_data,
+        },
+    )


### PR DESCRIPTION
Moved git_data inside try-except block, to avoid the following error in Juniper stage:
![Screenshot from 2020-11-25 10-30-14](https://user-images.githubusercontent.com/64440265/100240794-5a3b9f00-2f09-11eb-8d14-284d5eccd3a3.png)

This view is a copy from the plugin eox-hooks