### PR TITLE
Fix account activation email

### DIFF
--- a/eox_tenant/templatetags/ednx.py
+++ b/eox_tenant/templatetags/ednx.py
@@ -96,8 +96,7 @@ def microsite_get_value(value, *args, **kwargs):  # pylint: disable=unused-argum
         DeprecationWarning
     )
 
-    default = kwargs.get('default', None)
-    return configuration_helpers.get_value(value, default)
+    return tenant_get_value(value, *args, **kwargs)
 
 
 @register.simple_tag
@@ -225,4 +224,4 @@ def tenant_get_value(value, *args, **kwargs):  # pylint: disable=unused-argument
     Django template filter that wraps the configuration_helpers.get_value function
     """
     default = kwargs.get('default', None)
-    return configuration_helpers.get_value(value, default)
+    return configuration_helpers.get_value(value, getattr(settings, value, default))


### PR DESCRIPTION
This PR solves the branding issues in the account activation email.

When the account activation email is sent, the base template of the email calls the simple_tag microsite_get_value(), to obtain the EMAIL_LOGO_PATH value from the microsite and display it in the email.

As this email is sent by the async server, microsite_get_value() returns None, since at some point it has to call get_current_site() that does not find any request.

To solve this problem, the simple_tag tenant_get_value () (microsite_get_value () is deprecated) was modified so that it looks for the value directly in the settings when 'USE_EOX_TENANT' is True.