### PR TITLE
Add method validate_bearer_token to EoxTenantOAuth2Validator

### DIFF
--- a/eox_tenant/models.py
+++ b/eox_tenant/models.py
@@ -10,7 +10,7 @@ import six
 from django.db import connection, models
 from django.utils.translation import ugettext_lazy as _
 from jsonfield.fields import JSONField
-
+from oauth2_provider.models import AbstractAccessToken
 
 class TenantOrganization(models.Model):
     """
@@ -243,3 +243,8 @@ class Route(models.Model):
         Model meta class.
         """
         app_label = "eox_tenant"
+
+class EoxTenantAccessToken(AbstractAccessToken):
+    """"""
+    def is_valid(self, scopes=None):
+        """"""

--- a/eox_tenant/validators.py
+++ b/eox_tenant/validators.py
@@ -25,6 +25,6 @@ class EoxTenantOAuth2Validator(EdxOAuth2Validator):
         """Validates the token if the current url is in redirect_uris list."""
 
         if request.auth.application.redirect_uri_allowed(request.build_absolute_uri('/')):
-            super(EoxTenantOAuth2Validator, self).validate_bearer_token(token, scopes, request)
-            return True
+            return super(EoxTenantOAuth2Validator, self).validate_bearer_token(token, scopes, request)
+
         return False

--- a/eox_tenant/validators.py
+++ b/eox_tenant/validators.py
@@ -20,3 +20,6 @@ class EoxTenantOAuth2Validator(EdxOAuth2Validator):
 
         if request.client.redirect_uri_allowed(request_uri.build_absolute_uri('/')):
             super(EoxTenantOAuth2Validator, self).save_bearer_token(token, request, *args, **kwargs)
+
+    def validate_bearer_token():
+        """"""

--- a/eox_tenant/validators.py
+++ b/eox_tenant/validators.py
@@ -21,5 +21,10 @@ class EoxTenantOAuth2Validator(EdxOAuth2Validator):
         if request.client.redirect_uri_allowed(request_uri.build_absolute_uri('/')):
             super(EoxTenantOAuth2Validator, self).save_bearer_token(token, request, *args, **kwargs)
 
-    def validate_bearer_token():
-        """"""
+    def validate_bearer_token(self, token, scopes, request):
+        """Validates the token if the current url is in redirect_uris list."""
+
+        if request.auth.application.redirect_uri_allowed(request.build_absolute_uri('/')):
+            super(EoxTenantOAuth2Validator, self).validate_bearer_token(token, scopes, request)
+            return True
+        return False


### PR DESCRIPTION
This PR adds the method validate_bearer_token and modifies it to validate the actual url and the result from redirect_uri_allowed.