### PR TITLE
Fix token restriction.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,14 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[3.4.0] - 2021-01-22
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Added
+_____
+
+* New oauth2 validator in order to restrict the tokens creation.
+
 [3.3.7] - 2020-12-17
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -57,6 +57,8 @@ def plugin_settings(settings):
         'TenantSiteConfigProxy': True,
         'TenantGeneratedCertificateProxy': True,
     }
+    settings.OAUTH2_PROVIDER['OAUTH2_VALIDATOR_CLASS'] = 'eox_tenant.validators.EoxTenantOAuth2Validator'
+
     try:
         settings.MAKO_TEMPLATE_DIRS_BASE.insert(0, path(__file__).abspath().dirname().dirname() / 'templates')  # pylint: disable=no-value-for-parameter
     except AttributeError:

--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -8,7 +8,7 @@ from .common import *  # pylint: disable=wildcard-import
 
 class SettingsClass(object):
     """ dummy settings class """
-    pass
+    OAUTH2_PROVIDER = {}
 
 
 ALLOWED_HOSTS = ['*']


### PR DESCRIPTION
## Description
The method save_beare_token generated an 500 error when the site was not allowed hence the restriction was moved to `_load_application`.
