### PR TITLE
add: Change default backends to lilac

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,16 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[4.1.0] - 2021-10-27
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Added
+_______
+
+* Set Lilac backends as default in the Common settings file.
+* Update readme with new information and formats.
+
+
 [4.0.0] - 2021-05-10
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -37,12 +37,12 @@ def plugin_settings(settings):
     settings.CONTENTSTORE_PATH = 'cms.djangoapps.contentstore.utils'
     settings.EOX_TENANT_CACHE_KEY_TIMEOUT = 300
     settings.GET_OAUTH_DISPATCH_BACKEND = 'eox_tenant.edxapp_wrapper.backends.oauth_dispatch_j_v1'
-    settings.GET_BRANDING_API = 'eox_tenant.edxapp_wrapper.backends.branding_api_h_v1'
+    settings.GET_BRANDING_API = 'eox_tenant.edxapp_wrapper.backends.branding_api_l_v1'
     settings.GET_CERTIFICATES_MODULE = 'eox_tenant.edxapp_wrapper.backends.certificates_module_i_v1'
     settings.GET_SITE_CONFIGURATION_MODULE = 'eox_tenant.edxapp_wrapper.backends.site_configuration_module_i_v1'
     settings.GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_h_v1'
     settings.EOX_TENANT_EDX_AUTH_BACKEND = "eox_tenant.edxapp_wrapper.backends.edx_auth_i_v1"
-    settings.EOX_TENANT_USERS_BACKEND = 'eox_tenant.edxapp_wrapper.backends.users_i_v1'
+    settings.EOX_TENANT_USERS_BACKEND = 'eox_tenant.edxapp_wrapper.backends.users_l_v1'
     settings.EOX_MAX_CONFIG_OVERRIDE_SECONDS = 300
     settings.EDXMAKO_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.edxmako_h_v1'
     settings.UTILS_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.util_h_v1'


### PR DESCRIPTION
This PR adds the Lilac backends as default in the Common settings file to install the latest version of this plugin in the edunext-platform (Lilac)