### PR TITLE
fix: OAUTH2_PROVIDER test setting

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,19 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[5.0.0] - 2021-10-29
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Fixed
+_____
+
+* Changed OAUTH2_PROVIDER test setting to the platform value
+
+Changed
+_____
+
+* **BREAKING CHANGE**: Default backends for edxapp users and branding_api are not compatible with Juniper.
+
 [4.1.0] - 2021-10-27
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -85,3 +85,7 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     settings.GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_test_v1'
     settings.EOX_TENANT_SKIP_FILTER_FOR_TESTS = True
     settings.EOX_TENANT_LOAD_PERMISSIONS = False
+    settings.OAUTH2_PROVIDER['OAUTH2_VALIDATOR_CLASS'] = '{oauth_path}.{validator_path}'.format(
+        oauth_path='openedx.core.djangoapps',
+        validator_path='oauth_dispatch.dot_overrides.validators.EdxOAuth2Validator'
+    )


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

The platform tests for oauth_dispatch fail due to the override of the OAUTH2_PROVIDER['OAUTH2_VALIDATOR_CLASS'] setting

This PR changes the OAUTH2_PROVIDER plugin setting to its default to avoid the tests from the LMS from failing

## Checklist for Merge

- [ ] Tested in a remote environment / NA
- [x] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->