### PR TITLE
feat: adding support for messages passing via protocol V2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+Added
+_______
+
+* Support for message passing via protocol V2
+
 [5.0.1] - 2021-10-29
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/eox_tenant/test/test_signals.py
+++ b/eox_tenant/test/test_signals.py
@@ -285,6 +285,9 @@ class CeleryReceiverCLISyncTests(TestCase):
 
     def setUp(self):
         """ setup """
+        self.body = {
+            'kwargs': {},
+        }
         for number in range(3):
             Site.objects.create(
                 domain="tenant{number}.com".format(number=number),
@@ -296,8 +299,8 @@ class CeleryReceiverCLISyncTests(TestCase):
         When the task is unknown the hostname should be None.
         """
         headers = {}
-        body = {}
-        tenant_context_addition("uknown_task", headers=headers, body=body)
+
+        tenant_context_addition("uknown_task", headers=headers, body=self.body)
 
         self.assertIsNone(headers['eox_tenant_sender'])
 
@@ -307,13 +310,12 @@ class CeleryReceiverCLISyncTests(TestCase):
         When the task is called the method get_host_from_siteid should be called.
         """
         headers = {}
-        body = {}
 
         with self.settings():
             tenant_context_addition(
                 "openedx.core.djangoapps.schedules.tasks.ScheduleRecurringNudge",
                 headers=headers,
-                body=body,
+                body=self.body,
             )
 
         _get_host_mock.assert_called()
@@ -337,7 +339,9 @@ class CeleryReceiverSyncTests(TestCase):
         When the task is called from a sync proccess it is used the value of the 'host' key in the request dict.
         """
         headers = {}
-        body = {}
+        body = {
+            'kwargs': {},
+        }
         with self.settings(EDNX_TENANT_DOMAIN="some.tenant.com"):
             tenant_context_addition("some.task", headers=headers, body=body)
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
-
 django-crum==0.7.9
     # via -r requirements/base.in
 django-mysql==3.9.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
-
 click==7.1.2
     # via pip-tools
 pep517==0.10.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
-
 astroid==2.4.2
     # via
     #   -c requirements/constraints.txt

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,10 +4,6 @@
 #
 #    make upgrade
 #
---index-url http://edx.devstack.devpi:3141/root/pypi/+simple/
---extra-index-url https://pypi.python.org/simple
---trusted-host edx.devstack.devpi
-
 appdirs==1.4.4
     # via virtualenv
 distlib==0.3.1


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR adds support for message passing via protocol V2. Protocol 2 as opposed to protocol 1, doesn't allow sending custom headers, so we decided to send `eox_tenant_sender` inside the body's kwargs fixing the following error:
```
2021-11-17 19:42:04,799 INFO 547407 [celery.worker.strategy] [user None] [ip None] strategy.py:157 - Received task: eox_hooks.tasks.create_enrollments_for_program[3379139c-4892-4ba3-bf18-b05d1139542f]  
2021-11-17 19:42:04,803 WARNING 547931 [eox_tenant.signals] [user None] [ip None] signals.py:232 - Could not find the host information for eox_tenant.signals. 
2021-11-17 19:42:04,819 ERROR 547931 [eox_hooks.tasks] [user None] [ip None] tasks.py:58 - Couldn't create enrollment for course-v1:demo-site+DMS401+02 because the configuration is not valid: invalid organization or course mode.
2021-11-17 19:42:04,820 ERROR 547931 [eox_hooks.tasks] [user None] [ip None] tasks.py:58 - Couldn't create enrollment for course-v1:demo-site+DMS401+03 because the configuration is not valid: invalid organization or course mode.
2021-11-17 19:42:04,822 INFO 547931 [celery.app.trace] [user None] [ip None] trace.py:125 - Task eox_hooks.tasks.create_enrollments_for_program[3379139c-4892-4ba3-bf18-b05d1139542f] succeeded in 0.0194689710624516s: None
```
## Testing instructions

1. Using a previous version of eox-tenant, e.g. v5.0.1 
2. Deactivate a user
3. Try to login. The lms-worker will prompt
```
2021-11-17 19:42:04,803 WARNING 547931 [eox_tenant.signals] [user None] [ip None] signals.py:232 - Could not find the host information for eox_tenant.signals. 
```
3. Move to this branch. Try again login in, the task will work as expected.

## Additional information

Celery docs on messaging protocols:
Protocol V1 -> https://docs.celeryproject.org/en/v4.4.7/internals/protocol.html#version-1
Protocol V2 -> https://docs.celeryproject.org/en/v4.4.7/internals/protocol.html#version-2

We believe this change causes the error prohibiting sending custom headers:
![image](https://user-images.githubusercontent.com/64440265/142659139-2c3256ff-c2e5-4209-b5f3-eb97aacec54d.png)

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->