### PR TITLE
Return only a serializable subset of settings in `site_values`

### DIFF
--- a/eox_tenant/utils.py
+++ b/eox_tenant/utils.py
@@ -19,6 +19,41 @@ domain_pattern = re.compile(
     r'+[A-Za-z0-9][A-Za-z0-9-_]{0,61}'  # First 61 characters of the gTLD
     r'[A-Za-z]$'  # Last character of the gTLD
 )
+NON_SERIALIZABLE = object()
+
+
+def clean_serializable_values(obj):
+    """
+    Returns only serializable values
+
+    If an object is not json serializable returns NON_SERIALIZABLE.
+    In case of a list or dict ignore the NON_SERIALIZABLE values.
+    """
+    if isinstance(obj, (str, int, float, float, bool, type(None))):
+        return obj
+
+    if isinstance(obj, list):
+        return [
+            cleaned_item
+            for cleaned_item in (clean_serializable_values(item) for item in obj)
+            if cleaned_item is not NON_SERIALIZABLE
+        ]
+
+    if isinstance(obj, tuple):
+        return tuple(
+            cleaned_item
+            for cleaned_item in (clean_serializable_values(item) for item in obj)
+            if cleaned_item is not NON_SERIALIZABLE
+        )
+
+    if isinstance(obj, dict):
+        return {
+            key: cleaned_value
+            for key, cleaned_value in ((k, clean_serializable_values(v)) for k, v in obj.items())
+            if cleaned_value is not NON_SERIALIZABLE
+        }
+
+    return NON_SERIALIZABLE
 
 
 def is_valid_domain(domain):


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description
Some [recent changes](https://github.com/edx/edx-platform/pull/26435) use the value of `site_values` in the email templates context, this causes errors when attempting to serialize the email message because eox-tenant returns a dictionary with all the Django Settings values. To avoid this, only return a serializable subset of the settings.

## Testing instructions

Try to send an email (one of the easiest is account verification)
- Create a new user
- Set the user as inactive
- Try to login

The email should be sent without errors and with the correct context for the tenant.

## Additional information
I performed a small grep of `site_values` on edunext-platform and ignoring the test files and po files it's mostly used to obtain the value of `course_org_filter` and `COURSE_CATALOG_API_URL`.

Considering our current pattern is to access the modified settings object directly (usually via `getattr(setting, "MY_SETTING", default)` instead of interfacing through `SiteConfiguration` (this is mostly done by upstream, and the original `site_values` is a subset of what we are returning here in the proxy`) I think this change is safe.

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [x] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->