### PR TITLE
fix: add lilac backend for edxmako

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+Fixed
+-----
+
+* Update backend for edxmako so it's lilac compatible.
+
 [5.1.2] - 2021-12-02
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,7 @@ For version >= 3.4
 
   GET_BRANDING_API: 'eox_tenant.edxapp_wrapper.backends.branding_api_l_v1'
   EOX_TENANT_USERS_BACKEND: 'eox_tenant.edxapp_wrapper.backends.users_l_v1'
+  EDXMAKO_MODULE_BACKEND: eox_tenant.edxapp_wrapper.backends.edxmako_l_v1
 
 **Lilac**
 
@@ -63,6 +64,7 @@ For version >= 3.4
 
   GET_BRANDING_API: 'eox_tenant.edxapp_wrapper.backends.branding_api_l_v1'
   EOX_TENANT_USERS_BACKEND: 'eox_tenant.edxapp_wrapper.backends.users_l_v1'
+  EDXMAKO_MODULE_BACKEND: eox_tenant.edxapp_wrapper.backends.edxmako_l_v1
 
 Those settings can be changed in ``eox_tenant/settings/common.py`` or, for example, in ansible configurations.
 

--- a/eox_tenant/edxapp_wrapper/backends/edxmako_l_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/edxmako_l_v1.py
@@ -1,0 +1,8 @@
+""" Backend abstraction. """
+
+from common.djangoapps import edxmako  # pylint: disable=import-error
+
+
+def get_edxmako_module():
+    """ Backend to get edxmako module. """
+    return edxmako

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -44,7 +44,7 @@ def plugin_settings(settings):
     settings.EOX_TENANT_EDX_AUTH_BACKEND = "eox_tenant.edxapp_wrapper.backends.edx_auth_i_v1"
     settings.EOX_TENANT_USERS_BACKEND = 'eox_tenant.edxapp_wrapper.backends.users_l_v1'
     settings.EOX_MAX_CONFIG_OVERRIDE_SECONDS = 300
-    settings.EDXMAKO_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.edxmako_h_v1'
+    settings.EDXMAKO_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.edxmako_l_v1'
     settings.UTILS_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.util_h_v1'
     settings.CHANGE_DOMAIN_DEFAULT_SITE_NAME = "stage.edunext.co"
     settings.EOX_TENANT_LOAD_PERMISSIONS = True


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR(s) updates edxmako backend so it's lilac compatible.

## Testing instructions

Go to a tenant without configuration. Before this change, it'll crash and raise [this error](https://sentry.io/organizations/edunext/issues/2911742594/?project=6134348&query=&statsPeriod=14d).

## Additional information

[Sys path removal](https://github.com/openedx/edx-platform/blob/master/docs/decisions/0007-sys-path-modification-removal.rst)

## Checklist for Merge

- [x] Tested in a remote environment
- [x] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->