### PR TITLE
fix: Use get_current_site_orgs instead of get_value

### DIFF
--- a/eox_tenant/middleware.py
+++ b/eox_tenant/middleware.py
@@ -10,7 +10,6 @@ A microsite enables the following features:
 import logging
 import re
 
-import six
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.http import Http404, HttpResponseNotFound
@@ -23,7 +22,7 @@ from eox_tenant.edxapp_wrapper.site_configuration_module import get_configuratio
 from eox_tenant.edxapp_wrapper.theming_helpers import get_theming_helpers
 from eox_tenant.tenant_wise.proxies import TenantSiteConfigProxy
 
-configuration_helper = get_configuration_helpers()
+configuration_helpers = get_configuration_helpers()
 theming_helper = get_theming_helpers()
 HOST_VALIDATION_RE = re.compile(r"^(?:[0-9]{1,3}\.){3}[0-9]{1,3}(:[0-9]{2,5})?$")
 LOG = logging.getLogger(__name__)
@@ -55,14 +54,13 @@ class MicrositeCrossBrandingFilterMiddleware(MiddlewareMixin):
             raise Http404 from error
 
         # If the course org is the same as the current microsite
-        org_filter = configuration_helper.get_value('course_org_filter', set([]))
-        if isinstance(org_filter, six.string_types):
-            org_filter = set([org_filter])
-        if course_key.org in org_filter:
+        org_filter = configuration_helpers.get_current_site_orgs()
+
+        if isinstance(org_filter, list) and course_key.org in org_filter:
             return None
 
         # If the course does not belong to an ORG defined in a microsite
-        all_orgs = configuration_helper.get_all_orgs()
+        all_orgs = configuration_helpers.get_all_orgs()
         if course_key.org not in all_orgs:
             return None
 

--- a/eox_tenant/test/test_middleware.py
+++ b/eox_tenant/test/test_middleware.py
@@ -33,46 +33,46 @@ class MicrositeCrossBrandingFilterMiddlewareTest(TestCase):
 
         self.assertIsNone(self.middleware_instance.process_request(request))
 
-    @mock.patch('eox_tenant.middleware.configuration_helper')
+    @mock.patch('eox_tenant.middleware.configuration_helpers')
     def test_url_courses_match_org_in_filter(self, conf_helper_mock):
         """
         Test when request url match the course id pattern but the course org
         belongs to the current site/microsite
         """
         request = self.request_factory.get('/courses/course-v1:TEST_ORG+CS101+2019_T1/')
-        conf_helper_mock.get_value.return_value = ['TEST_ORG']
+        conf_helper_mock.get_current_site_orgs.return_value = ['TEST_ORG']
 
         self.assertIsNone(self.middleware_instance.process_request(request))
-        conf_helper_mock.get_value.assert_called_once()
+        conf_helper_mock.get_current_site_orgs.assert_called_once()
         conf_helper_mock.get_all_orgs.assert_not_called()
 
-    @mock.patch('eox_tenant.middleware.configuration_helper')
+    @mock.patch('eox_tenant.middleware.configuration_helpers')
     def test_url_courses_match_org_not_in_all_orgs(self, conf_helper_mock):
         """
         Test when request url match the course id pattern but the course org
         does not belong to any site/microsite
         """
         request = self.request_factory.get('/courses/course-v1:TEST_ORG+CS101+2019_T1/')
-        conf_helper_mock.get_value.return_value = []
+        conf_helper_mock.get_current_site_orgs.return_value = []
         conf_helper_mock.get_all_orgs.return_value = ['Some_org', 'new_org', 'other_org']
 
         self.assertIsNone(self.middleware_instance.process_request(request))
-        conf_helper_mock.get_value.assert_called_once()
+        conf_helper_mock.get_current_site_orgs.assert_called_once()
         conf_helper_mock.get_all_orgs.assert_called_once()
 
-    @mock.patch('eox_tenant.middleware.configuration_helper')
+    @mock.patch('eox_tenant.middleware.configuration_helpers')
     def test_url_courses_match_org_in_other_site(self, conf_helper_mock):
         """
         Test when request url match the course id pattern but the course org
         does belong to any site/microsite
         """
         request = self.request_factory.get('/courses/course-v1:TEST_ORG+CS101+2019_T1/')
-        conf_helper_mock.get_value.return_value = ['other_org']
+        conf_helper_mock.get_current_site_orgs.return_value = ['other_org']
         conf_helper_mock.get_all_orgs.return_value = ['Some_org', 'new_org', 'TEST_ORG']
 
         with self.assertRaises(Http404) as _:
             self.middleware_instance.process_request(request)
-            conf_helper_mock.get_value.assert_called_once()
+            conf_helper_mock.get_current_site_orgs.assert_called_once()
             conf_helper_mock.get_all_orgs.assert_called_once()
 
 


### PR DESCRIPTION
## Description

the method [get_value](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/site_configuration/helpers.py#L119) tries to perform a dictionary update using the found value, this should fail if the value is not a dictionary however when the course_org_filter is a list with an org of two letters, this doesn't fail, this performs the update a return a dictionary 

### Example
```
# Given the following
course_org_filter = ["AB"]
# The following line will return {"A": "B"}
configuration_helper.get_value('course_org_filter', set([]))
```
the method [get_current_site_orgs()](https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/site_configuration/helpers.py#L216) perfoms the verification and return the right value

## Testing instructions
Add MicrositeCrossBrandingFilterMiddleware middleware
Create a site with course_org_filter = ["AB"]
Create a course in that org
Try to get the course -> Current behavior return 404, new behavior return the course

## Additional information

NA

## Checklist for Merge

- [x] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->