### PR TITLE
feat: add BearerAuthentication to API

### DIFF
--- a/eox_tenant/api/v1/permissions.py
+++ b/eox_tenant/api/v1/permissions.py
@@ -1,13 +1,66 @@
 """
 Permission for eox_tenant api v1.
 """
-from rest_framework import permissions
+from django.conf import settings
+from django.contrib.auth.models import Permission, User
+from django.contrib.contenttypes.models import ContentType
+from django.db.utils import ProgrammingError
+from rest_framework import exceptions, permissions
+
+
+def load_permissions():
+    """
+    Helper method to load a custom permission on DB that will be
+    used to give access to the eox-tenant API.
+    """
+    if settings.EOX_TENANT_LOAD_PERMISSIONS:
+        try:
+            content_type = ContentType.objects.get_for_model(User)
+            Permission.objects.get_or_create(  # pylint: disable=unused-variable
+                codename='can_call_eox_tenant',
+                name='Can access eox-tenant API',
+                content_type=content_type,
+            )
+        except ProgrammingError:
+            # This code runs when the app is loaded, if a migration has not been
+            # done a ProgrammingError exception is raised.
+            # we are bypassing those cases to let migrations run smoothly.
+            pass
 
 
 class EoxTenantAPIPermission(permissions.BasePermission):
-    """Only allows super user."""
+    """
+    Defines a custom permissions to access eox-tenant API.
+    These permissions make sure that a token is created with the client credentials of the same site is
+    being used on, and the user has a valid SignUp source for the site.
+    """
 
     def has_permission(self, request, view):
-        if request.user.is_superuser:
+        """
+        To grant access, checks if the requesting user:
+            1) it's a staff user
+            3) it's calling the API from a site authorized by the auth application or client
+            4) has can call eox-tenant API permission
+        """
+        user = request.user
+
+        if user.is_staff:
             return True
-        return False
+
+        try:
+            application_uri_allowed = request.auth.application.redirect_uri_allowed(request.build_absolute_uri('/'))
+        except Exception:  # pylint: disable=broad-except
+            application_uri_allowed = False
+
+        try:
+            client_url_allowed = request.get_host() in request.auth.client.url
+        except Exception:  # pylint: disable=broad-except
+            client_url_allowed = False
+
+        if client_url_allowed or application_uri_allowed:
+            return user.has_perm('auth.can_call_eox_tenant')
+
+        # If we get here either someone is using a token created on one site in a different site
+        # or there was a missconfiguration of the oauth client.
+        # we return the most basic message to prevent leaking important information .
+        raise exceptions.NotAuthenticated(detail="Invalid token")

--- a/eox_tenant/api/v1/tests/test_microsites.py
+++ b/eox_tenant/api/v1/tests/test_microsites.py
@@ -129,9 +129,3 @@ class MicrositeAPITest(APITestCase):
         response = self.client.delete(self.url_detail)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-
-    def test_permissions_microsite(self):
-        """Must return 403, only allows superuser."""
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/eox_tenant/api/v1/tests/test_permissions.py
+++ b/eox_tenant/api/v1/tests/test_permissions.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Test module for the permissions class
+"""
+from django.test import TestCase
+from mock import MagicMock
+from rest_framework.exceptions import NotAuthenticated
+
+from eox_tenant.api.v1.permissions import EoxTenantAPIPermission
+
+
+class EoxTenantAPIPermissionTest(TestCase):
+    """ Test cases for the EoxTenantAPIPermission class."""
+
+    def test_permissions_for_staff(self):
+        """ Staff always passes."""
+        request = MagicMock()
+        request.user.is_staff = True
+
+        has_perm = EoxTenantAPIPermission().has_permission(request, MagicMock())
+
+        self.assertTrue(has_perm)
+
+    def test_read_user_permissions(self):
+        """ If the auth does not fail, it comes down to check the
+        domain in the client or application.
+
+        Expected behavior:
+            has_permission method returns False
+        """
+        request = MagicMock()
+        request.user.is_staff = False
+        request.user.has_perm.return_value = False
+
+        has_perm = EoxTenantAPIPermission().has_permission(request, MagicMock())
+
+        self.assertFalse(has_perm)
+
+    def test_permissions_without_auth(self):
+        """ If anything in the auth fails, the NotAuthenticated exception is raised
+
+        Expected behavior:
+            NotAuthenticated exception is raised
+        """
+        request = MagicMock()
+        request.user.is_staff = False
+        request.user.has_perm.return_value = False
+        request.auth = None
+
+        with self.assertRaises(NotAuthenticated):
+            EoxTenantAPIPermission().has_permission(request, MagicMock())
+
+    def test_permissions_auth_dop(self):
+        """ Authorize the domain via the client.url.
+
+        Expected behavior:
+            has_permission method returns False
+        """
+        request = MagicMock()
+        request.user.is_staff = False
+        request.user.has_perm.return_value = True
+        request.get_host.return_value = "domain.com"
+        request.auth.client.url = "https://domain.com/"
+
+        has_perm = EoxTenantAPIPermission().has_permission(request, MagicMock())
+
+        self.assertTrue(has_perm)
+
+    def test_permissions_auth_dot(self):
+        """ Authorize the domain via the application.allowed_uris
+
+        Expected behavior:
+            has_permission method returns False
+        """
+        request = MagicMock()
+        request.user.is_staff = False
+        request.user.has_perm.return_value = True
+        request.auth.application.redirect_uri_allowed.return_value = True
+
+        has_perm = EoxTenantAPIPermission().has_permission(request, MagicMock())
+
+        self.assertTrue(has_perm)

--- a/eox_tenant/api/v1/tests/test_routes.py
+++ b/eox_tenant/api/v1/tests/test_routes.py
@@ -119,9 +119,3 @@ class RouteAPITest(APITestCase):
         response = self.client.patch(self.url_detail, data=data, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-    def test_permissions_route(self):
-        """Must return 403, only allows superuser."""
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/eox_tenant/api/v1/tests/test_tenant_config.py
+++ b/eox_tenant/api/v1/tests/test_tenant_config.py
@@ -134,9 +134,3 @@ class TenantConfigAPITest(APITestCase):
         response = self.client.delete(self.url_detail)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-
-    def test_permissions_tenant_config(self):
-        """Must return 403, only allows superuser."""
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/eox_tenant/api/v1/viewsets.py
+++ b/eox_tenant/api/v1/viewsets.py
@@ -2,16 +2,19 @@
 API v1 viewsets.
 """
 from rest_framework import viewsets
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.parsers import JSONParser
 
 from eox_tenant.api.v1.permissions import EoxTenantAPIPermission
 from eox_tenant.api.v1.serializers import MicrositeSerializer, RouteSerializer, TenantConfigSerializer
+from eox_tenant.edxapp_wrapper.bearer_authentication import BearerAuthentication
 from eox_tenant.models import Microsite, Route, TenantConfig
 
 
 class MicrositeViewSet(viewsets.ModelViewSet):
     """MicrositeViewSet that allows the basic API actions."""
 
+    authentication_classes = (BearerAuthentication, SessionAuthentication)
     parser_classes = [JSONParser]
     permission_classes = [EoxTenantAPIPermission]
     serializer_class = MicrositeSerializer
@@ -21,6 +24,7 @@ class MicrositeViewSet(viewsets.ModelViewSet):
 class TenantConfigViewSet(viewsets.ModelViewSet):
     """TenantConfigViewSet that allows the basic API actions."""
 
+    authentication_classes = (BearerAuthentication, SessionAuthentication)
     parser_classes = [JSONParser]
     permission_classes = [EoxTenantAPIPermission]
     serializer_class = TenantConfigSerializer
@@ -30,6 +34,7 @@ class TenantConfigViewSet(viewsets.ModelViewSet):
 class RouteViewSet(viewsets.ModelViewSet):
     """RouteViewSet that allows the basic API actions."""
 
+    authentication_classes = (BearerAuthentication, SessionAuthentication)
     parser_classes = [JSONParser]
     permission_classes = [EoxTenantAPIPermission]
     serializer_class = RouteSerializer

--- a/eox_tenant/apps.py
+++ b/eox_tenant/apps.py
@@ -94,6 +94,10 @@ class EdunextOpenedxExtensionsTenantConfig(AppConfig):
         """
         Method to perform actions after apps registry is ended
         """
+        from eox_tenant.api.v1.permissions import \
+            load_permissions as load_api_permissions  # pylint: disable=import-outside-toplevel
+        load_api_permissions()
+
         from eox_tenant.permissions import load_permissions  # pylint: disable=import-outside-toplevel
         load_permissions()
 

--- a/eox_tenant/edxapp_wrapper/backends/bearer_authentication_l_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/bearer_authentication_l_v1.py
@@ -1,0 +1,16 @@
+"""Backend for authentication.
+
+This file contains all the necessary authentication dependencies from
+https://github.com/eduNEXT/edunext-platform/tree/master/openedx/core/lib/api/authentication.py
+"""
+from openedx.core.lib.api.authentication import BearerAuthentication  # pylint: disable=import-error
+
+
+def get_bearer_authentication():
+    """Allow to get the function BearerAuthentication from
+    https://github.com/eduNEXT/edunext-platform/tree/master/openedx/core/lib/api/authentication.py
+
+    Returns:
+        BearerAuthentication function.
+    """
+    return BearerAuthentication

--- a/eox_tenant/edxapp_wrapper/backends/bearer_authentication_test_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/bearer_authentication_test_v1.py
@@ -1,0 +1,15 @@
+""" Backend test abstraction. """
+
+
+def get_bearer_authentication():
+    """Allow to get the function BearerAuthentication from
+    https://github.com/eduNEXT/edunext-platform/tree/master/openedx/core/lib/api/authentication.py
+
+    Returns:
+        BearerAuthentication function.
+    """
+    try:
+        from openedx.core.lib.api.authentication import BearerAuthentication  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        BearerAuthentication = object
+    return BearerAuthentication

--- a/eox_tenant/edxapp_wrapper/bearer_authentication.py
+++ b/eox_tenant/edxapp_wrapper/bearer_authentication.py
@@ -1,0 +1,17 @@
+"""
+Bearer Authentication definition.
+"""
+from importlib import import_module
+
+from django.conf import settings
+
+
+def get_bearer_authentication():
+    """ Gets BearerAuthentication class. """
+    backend_function = settings.EOX_TENANT_BEARER_AUTHENTICATION
+    backend = import_module(backend_function)
+
+    return backend.get_bearer_authentication()
+
+
+BearerAuthentication = get_bearer_authentication()  # pylint: disable=invalid-name

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -43,6 +43,7 @@ def plugin_settings(settings):
     settings.GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_h_v1'
     settings.EOX_TENANT_EDX_AUTH_BACKEND = "eox_tenant.edxapp_wrapper.backends.edx_auth_i_v1"
     settings.EOX_TENANT_USERS_BACKEND = 'eox_tenant.edxapp_wrapper.backends.users_l_v1'
+    settings.EOX_TENANT_BEARER_AUTHENTICATION = 'eox_tenant.edxapp_wrapper.backends.bearer_authentication_l_v1'
     settings.EOX_MAX_CONFIG_OVERRIDE_SECONDS = 300
     settings.EDXMAKO_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.edxmako_l_v1'
     settings.UTILS_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.util_h_v1'

--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -32,6 +32,7 @@ GET_CERTIFICATES_MODULE = 'eox_tenant.edxapp_wrapper.backends.certificates_modul
 GET_SITE_CONFIGURATION_MODULE = 'eox_tenant.edxapp_wrapper.backends.site_configuration_module_test_v1'
 GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_test_v1'
 EOX_TENANT_USERS_BACKEND = 'eox_tenant.edxapp_wrapper.backends.users_test_v1'
+EOX_TENANT_BEARER_AUTHENTICATION = 'eox_tenant.edxapp_wrapper.backends.bearer_authentication_test_v1'
 
 COURSE_KEY_PATTERN = r'(?P<course_key_string>[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'
 COURSE_ID_PATTERN = COURSE_KEY_PATTERN.replace('course_key_string', 'course_id')


### PR DESCRIPTION
## Description

Currently, the tenant API permission class [EoxTenantAPIPermission](https://github.com/eduNEXT/eox-tenant/blob/master/eox_tenant/api/v1/permissions.py#L11) only allows superusers to make requests through a basic auth scheme.

https://github.com/eduNEXT/eox-tenant/blob/master/eox_tenant/api/v1/permissions.py#L10-L13

In this PR we add a Bearer authentication scheme to the API

A new file containing the tests for the API permissions was added, and the test cases for the permissions were removed from the API tests.

### More details on the implementation

This implementation was based on the eox-core API permission protocol
https://github.com/eduNEXT/eox-core/blob/master/eox_core/api/v1/permissions.py#L32
 
To grant access, the EoxTenantAPIPermission class now checks multiple things:

- Staff members always have access, so If the requesting user is staff, returns True.
- For a non-staff user: 
  - If there is no valid SignUp source for the user and site from the request, then returns False. 
  - If the user is calling the API from a valid source,  then checks if the domain is authorized by the auth application.allowed_uris or client.URL. 
  -  Finally, if the site is authorized by the Auth, validates that the user has the **can call eox-tenant API** permission

### Why are these changes necessary?

The Xman service needs to communicate with the tenant-API to perform operations on a remote Site in edxapp. However, the protocol in Xman to authenticate in a remote site requires the external API to allow a Bearer Token authentication scheme.
https://github.com/eduNEXT/xman/blob/master/apps/tenant_comm_manager/models.py#L147

By applying these changes we are making sure that the Xman service can safely authenticate to the tenant-API and make external requests to perform operations over a specific Microsite or Tenant Config.

## Testing instructions

STEPS

1. Create an application for the user in `<lms-domain>/admin/oauth2_provider/application/`
2. Add the user to the **EOX Core API access** Group
3. Add a SignUp source instance with the user and the site from where the API calls will be made `<lms-domain>/admin/student/usersignupsource/`
4. Generate a token with the client ID and client secret from the Application `<domain>/oauth2/access_token/`
5. make requests to the eox-tenant API using BearerAuthentication

You can also test using a staff user that does not have a signup source on the request site, and it should grant access to the API

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits