### PR TITLE
(FFI-3/DS-300) filter user's course enrollment by microsite request

### DIFF
--- a/eox_tenant/filters/README.rst
+++ b/eox_tenant/filters/README.rst
@@ -1,0 +1,27 @@
+Customs Filters Steps Pipelines
+===============================
+
+The purpose of these pipelines is to use the filters that are structured in `openedx-filters`_ and
+implemented in `edx-platform`_. From the creation of a custom filter pipeline in this space, we can
+overwrite the one of the structure in ``openedx-filter`` so that it executes the action that we want, where
+the filter is implemented in ``edx-platform``.
+
+ .. _openedx-filters: https://github.com/openedx/openedx-filters
+ .. _edx-platform: https://github.com/openedx/edx-platform
+
+Filters steps list:
+-------------------
+
+* `FilterUserCourseEnrollmentsByTenant`_: Filters the course enrollments of a user from the tenant site where the request is made.
+
+.. _FilterUserCourseEnrollmentsByTenant: ./pipeline.py#L9
+
+How to add a new Filter Step:
+-----------------------------
+
+Add a new Filter Step in `pipeline.py`_ file, note that this must exist in ``openedx-filters`` in order to be
+called. Find a `list of filters`_ that exist so far and `how to implement`_ it.
+
+.. _pipeline.py: ./pipeline.py
+.. _list of filters: https://github.com/openedx/openedx-filters/blob/main/openedx_filters/learning/filters.py
+.. _how to implement: https://github.com/openedx/openedx-filters/tree/main/docs/decisions

--- a/eox_tenant/filters/__init__.py
+++ b/eox_tenant/filters/__init__.py
@@ -1,0 +1,3 @@
+"""
+Where Open edX Filter steps are implemented.
+"""

--- a/eox_tenant/filters/pipeline.py
+++ b/eox_tenant/filters/pipeline.py
@@ -1,0 +1,29 @@
+"""
+The pipeline module defines custom Filters functions that are used in openedx-filters.
+"""
+from openedx_filters import PipelineStep
+
+from eox_tenant.tenant_aware_functions.enrollments import filter_enrollments
+
+
+class FilterUserCourseEnrollmentsByTenant(PipelineStep):
+    """
+    Filter enrollments list by a tenant.
+    """
+
+    def run_filter(self, context):  # pylint: disable=arguments-differ
+        """
+        Filter especific user course enrollments by tenant request.
+        Example Usage:
+        Add the following configurations to you configuration file
+            "OPEN_EDX_FILTERS_CONFIG": {
+                "org.openedx.learning.course_enrollments_site.filter.requested.v1": {
+                    "fail_silently": false,
+                    "pipeline": [
+                        "eox_tenant.filters.pipeline.FilterUserCourseEnrollmentsByTenant"
+                    ]
+                }
+            }
+        """
+        tenant_enrollments = filter_enrollments(context)
+        return {"context": tenant_enrollments}

--- a/eox_tenant/filters/test/test_pipeline.py
+++ b/eox_tenant/filters/test/test_pipeline.py
@@ -1,0 +1,140 @@
+"""
+Test cases for Open edX Filters steps.
+"""
+from unittest.mock import MagicMock
+
+import mock
+from django.test import TestCase, override_settings
+from openedx_filters.tooling import OpenEdxPublicFilter
+
+from eox_tenant.tenant_aware_functions.enrollments import filter_enrollments
+
+
+# This class was temporarily added while the filter is added in openedx-filters.
+class CourseEnrollmentSiteFilterRequested(OpenEdxPublicFilter):
+    """
+    Custom class used to filter user's course enrollments by site.
+    """
+
+    filter_type = "org.openedx.learning.course_enrollments_site.filter.requested.v1"
+
+    @classmethod
+    def run_filter(cls, context):
+        """
+        Execute a filter with the signature specified.
+
+        Arguments:
+        context (QuerySet): list of all user's course enrollments.
+        """
+        data = super().run_pipeline(context=context)
+        return data.get("context")
+
+
+class FilterStepsTestCase(TestCase):
+    """
+    Filtet steps test cases.
+    """
+
+    def setUp(self):
+        """This method creates Microsite objects in database"""
+
+        # Creating mock enrollments
+        orgs_for_enrolls = ["org1", "demo", "org3"]
+        enrolls = []
+        for org in orgs_for_enrolls:
+            enroll_mock = MagicMock()
+            enroll_mock.course_id.org = org
+            enrolls.append(enroll_mock)
+        self.course_enrollments = enrolls
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.course_enrollments_site.filter.requested.v1": {
+                "fail_silently": False,
+                "pipeline": [
+                    "eox_tenant.filters.pipeline.FilterUserCourseEnrollmentsByTenant"
+                ],
+            }
+        }
+    )
+    @mock.patch("eox_tenant.tenant_aware_functions.enrollments.get_theming_helpers")
+    @mock.patch(
+        "eox_tenant.tenant_aware_functions.enrollments.get_configuration_helpers"
+    )
+    def test_filter_user_course_enrollments(
+        self, get_conf_helpers_mock, get_theming_helpers_mock
+    ):
+        """
+        Test that filter user course enrollments are made by site.
+        """
+        results_get_value = {"course_org_filter": ["demo"]}
+
+        def side_effect_get_value(key, default=None):
+            """
+            Mock side effect
+            """
+            return results_get_value.get(key, default)
+
+        conf_helpers_mock = MagicMock()
+        theming_helpers_mock = MagicMock()
+        conf_helpers_mock.get_value.side_effect = side_effect_get_value
+        theming_helpers_mock.is_request_in_themed_site.return_value = True
+
+        get_conf_helpers_mock.return_value = conf_helpers_mock
+        get_theming_helpers_mock.return_value = theming_helpers_mock
+
+        expected_result = filter_enrollments(self.course_enrollments)
+
+        result = CourseEnrollmentSiteFilterRequested.run_filter(
+            context=self.course_enrollments
+        )
+        expected_result = list(expected_result)
+        result = list(result)
+
+        self.assertListEqual(expected_result, result)
+        self.assertEqual(expected_result[0].course_id.org, result[0].course_id.org)
+
+    @override_settings(
+        OPEN_EDX_FILTERS_CONFIG={
+            "org.openedx.learning.course_enrollments_site.filter.requested.v1": {
+                "fail_silently": False,
+                "pipeline": [
+                    "eox_tenant.filters.pipeline.FilterUserCourseEnrollmentsByTenant"
+                ],
+            }
+        }
+    )
+    @mock.patch("eox_tenant.tenant_aware_functions.enrollments.get_theming_helpers")
+    @mock.patch(
+        "eox_tenant.tenant_aware_functions.enrollments.get_configuration_helpers"
+    )
+    def test_filter_user_not_course_enrollments(
+        self, get_conf_helpers_mock, get_theming_helpers_mock
+    ):
+        """
+        Test filter when a user is not enroll in any course in the site.
+        """
+        results_get_value = {}
+
+        def side_effect_get_value(key, default=None):
+            """
+            Mock side effect
+            """
+            return results_get_value.get(key, default)
+
+        conf_helpers_mock = MagicMock()
+        theming_helpers_mock = MagicMock()
+        conf_helpers_mock.get_value.side_effect = side_effect_get_value
+        theming_helpers_mock.is_request_in_themed_site.return_value = True
+        conf_helpers_mock.get_all_orgs.return_value = ["org1", "demo", "org3"]
+
+        get_conf_helpers_mock.return_value = conf_helpers_mock
+        get_theming_helpers_mock.return_value = theming_helpers_mock
+
+        expected_result = filter_enrollments(self.course_enrollments)
+
+        result = CourseEnrollmentSiteFilterRequested.run_filter(
+            context=self.course_enrollments
+        )
+
+        self.assertListEqual(list(expected_result), list(result))

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -8,3 +8,4 @@ django-crum
 django-mysql
 jsonfield
 edx-opaque-keys[django]
+openedx_filters

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via django
 django==3.2.15
     # via
@@ -14,6 +14,7 @@ django==3.2.15
     #   django-mysql
     #   djangorestframework
     #   jsonfield
+    #   openedx-filters
 django-crum==0.7.9
     # via
     #   -c requirements/constraints.txt
@@ -34,13 +35,17 @@ jsonfield==3.1.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-pbr==5.8.1
+openedx-filters==0.8.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+pbr==5.11.0
     # via stevedore
 pymongo==3.10.1
     # via
     #   -c requirements/constraints.txt
     #   edx-opaque-keys
-pytz==2021.3
+pytz==2022.6
     # via
     #   django
     #   djangorestframework
@@ -48,7 +53,7 @@ six==1.16.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-sqlparse==0.4.2
+sqlparse==0.4.3
     # via django
-stevedore==3.5.0
+stevedore==4.1.1
     # via edx-opaque-keys

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -24,3 +24,4 @@ path-py==12.5.0
 pycodestyle==2.8.0
 pylint==2.12.2
 testfixtures==6.18.4
+openedx_filters==0.8.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,15 +4,23 @@
 #
 #    make upgrade
 #
-click==8.0.4
+build==0.9.0
     # via pip-tools
-pep517==0.12.0
+click==8.1.3
     # via pip-tools
-pip-tools==6.5.1
+packaging==21.3
+    # via build
+pep517==0.13.0
+    # via build
+pip-tools==6.10.0
     # via -r requirements/pip-tools.in
+pyparsing==3.0.9
+    # via packaging
 tomli==2.0.1
-    # via pep517
-wheel==0.37.1
+    # via
+    #   build
+    #   pep517
+wheel==0.38.4
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-asgiref==3.5.0
+asgiref==3.5.2
     # via
     #   -r requirements/base.txt
     #   django
@@ -25,6 +25,7 @@ ddt==1.4.4
     #   django-mysql
     #   djangorestframework
     #   jsonfield
+    #   openedx-filters
 django-crum==0.7.9
     # via
     #   -c requirements/constraints.txt
@@ -51,7 +52,7 @@ jsonfield==3.1.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-lazy-object-proxy==1.7.1
+lazy-object-proxy==1.8.0
     # via astroid
 mccabe==0.6.1
     # via pylint
@@ -59,17 +60,21 @@ mock==4.0.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
-path==16.4.0
+openedx-filters==0.8.0
+    # via
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.txt
+path==16.5.0
     # via path-py
 path-py==12.5.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
-pbr==5.8.1
+pbr==5.11.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==2.5.1
+platformdirs==2.5.4
     # via pylint
 pycodestyle==2.8.0
     # via
@@ -84,7 +89,7 @@ pymongo==3.10.1
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   edx-opaque-keys
-pytz==2021.3
+pytz==2022.6
     # via
     #   -r requirements/base.txt
     #   django
@@ -93,11 +98,11 @@ six==1.16.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-sqlparse==0.4.2
+sqlparse==0.4.3
     # via
     #   -r requirements/base.txt
     #   django
-stevedore==3.5.0
+stevedore==4.1.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -109,7 +114,7 @@ toml==0.10.2
     # via pylint
 tomli==2.0.1
     # via coverage
-typing-extensions==4.1.1
+typing-extensions==4.4.0
     # via
     #   astroid
     #   pylint

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -4,30 +4,29 @@
 #
 #    make upgrade
 #
-distlib==0.3.4
+distlib==0.3.6
     # via virtualenv
-filelock==3.6.0
+filelock==3.8.0
     # via
     #   tox
     #   virtualenv
 packaging==21.3
     # via tox
-platformdirs==2.5.1
+platformdirs==2.5.4
     # via virtualenv
 pluggy==1.0.0
     # via tox
 py==1.11.0
     # via tox
-pyparsing==3.0.7
+pyparsing==3.0.9
     # via packaging
 six==1.16.0
     # via
     #   -c requirements/constraints.txt
     #   tox
-    #   virtualenv
-toml==0.10.2
+tomli==2.0.1
     # via tox
-tox==3.24.5
+tox==3.27.1
     # via -r requirements/tox.in
-virtualenv==20.13.2
+virtualenv==20.16.7
     # via tox


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR adds a custom filter pipeline to get course enrollments from tenant site where a user makes the request.

The idea is including some changes in _openedx-filters_ and _edx-platform_ repositories to anyone implement the filter function, and one clear example to use is this custom pipeline on eox-tenant plugin.

**Dependencies for now**:
- https://github.com/eduNEXT/edunext-platform/pull/696

**Future dependencies**:
- openedx/openedx-filters
- openedx/edx-platfom

## Testing instructions

1. Create an environment, you can use strain.yml bellow.

```yml
STRAIN_NAME: nuez
STRAIN_TUTOR_VERSION: v14.1.0
DOCKER_IMAGE_OPENEDX_DEV: docker.io/ednxops/distro-edunext-edxapp-dev:nuez
DOCKER_IMAGE_OPENEDX: docker.io/ednxops/distro-edunext-edxapp:nuez
EDX_PLATFORM_REPOSITORY: https://github.com/eduNEXT/edunext-platform.git
EDX_PLATFORM_VERSION: ednx-release/nuez.master
CMS_HOST: studio.nutmeg.edunext.link
LMS_HOST: lms.nutmeg.edunext.link
DEV_PROJECT_NAME: nuez_dev
LOCAL_PROJECT_NAME: nuez_local
PLATFORM_NAME: Nuez
STRAIN_TUTOR_PLUGINS:
  - REPO: tutor-contrib-edunext-distro
    VERSION: v3.0.0
    EGG: tutor-contrib-edunext-distro==v3.0.0
    PACKAGE_NAME: distro
    PROTOCOL: ssh
STRAIN_EXTRA_COMMANDS:
  - APP: 'tutor'
    COMMAND: 'distro enable-themes'
DISTRO_EOX_TENANT_DPKG:
  index: git
  name: eox-tenant
  private: false
  repo: eox-tenant
  domain: github.com
  path: eduNEXT
  protocol: https
  variables:
    development: {}
    production: {}
  version: JDB/add_filter_enrollment_site
DISTRO_THEMES_NAME:
  - bragi
```
2. Create two Tenant sites and add at less one course on each one. Go on to create sites: http://lms.nutmeg.edunext.link:8000/admin/eox_tenant/tenantconfig/
3. In a course, in Studio, set ``Mobile Course Available`` true. Go on to configure the key: studio.nutmeg.edunext.link:8001/settings/advanced/{your_course_id}
4. Enroll a user (user don't have to be a staff user) in a course on different sites.
5. Add the following configurations to your configuration site.
```json
"OPEN_EDX_FILTERS_CONFIG": {
    "org.openedx.learning.course_enrollments_site.filter.requested.v1": {
        "fail_silently": false,
        "pipeline": [
            "eox_tenant.filters.pipeline.FilterUserCourseEnrollmentsByTenant"
        ]
    }
},
```
6. Make a request in:
- my_microsite.nutmeg.edunext.link:8000/api/enrollment/v1/enrollment
- my_microsite.nutmeg.edunext.link:8000/api/mobile/v1/users/{username}/course_enrollments/
7. You should see the courses where you are enrolled. Check when you don't use ``OPEN_EDX_FILTERS_CONFIG`` in your site, the request show all courses.

## Additional information

- Test cases file: https://docs.google.com/document/d/1BPtbBg0hsp4Bd3IcrEYhy2gNNN3enLz5sziYrqXZdrY/edit?usp=sharing

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->