### PR TITLE
ci: update the changelog updater step in bumpversion DS-305

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -33,7 +33,7 @@ jobs:
           bumpversion --new-version ${{ steps.tag_version.outputs.new_version }} setup.cfg
       - name: Update Changelog
         if: steps.tag_version.outputs.new_version
-        uses: stefanzweifel/changelog-updater-action@v1.6.0
+        uses: stefanzweifel/changelog-updater-action@v1.6.2
         with:
           latest-version: ${{ steps.tag_version.outputs.new_tag }}
           release-notes: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR updates the version of the changelog updater. This correct the error creating the version in eox-tenant.

## How to test

I replicated the error in a fork and changed the version, and it works. 

![image](https://user-images.githubusercontent.com/35668326/208522203-b863a3c9-0b8c-4364-a60d-66a7ea039041.png)
In my fork: in the docs commit, I have the same error in eduNEXT; and the next commit fixed it.

Fork: https://github.com/MaferMazu/eox-tenant/commits/master



<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->