### PR TITLE
feat: add route domain to proxy also the `domain`

### DIFF
--- a/eox_tenant/middleware.py
+++ b/eox_tenant/middleware.py
@@ -109,4 +109,5 @@ class CurrentSiteMiddleware(MiddlewareMixin):
         """
         site = get_current_site(request)
         site.configuration = TenantSiteConfigProxy()
+        site.domain = getattr(settings, 'EDNX_TENANT_DOMAIN', site.domain)
         request.site = site


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This adds the route domain if the tenant has tenant route a associated. This also avoids the creation of a site record with the same domain as a route created.

By the moment the objective branch is `open-release/mango.master` https://github.com/eduNEXT/eox-tenant/tree/open-release/mango.master a branch that I created from the v6.2.0 release. Because is the version eox-tenant in nelp is being used: https://github.com/eduNEXT/ednx-strains/blob/open-release/nelp/nelp/mango/strain.yml#L174


Useful information to include:
- This is very helpful for views that use `site.domain`. 
![Peek 2023-01-13 19-23](https://user-images.githubusercontent.com/51926076/212441169-6cc761c6-02f8-4e2c-b4f6-02b00f40d6c8.gif)
In nelp there was a case when rendering the program's view was failing due to the build of the domain didn't exist or being wrong.
https://github.com/openedx/edx-platform/blob/master/lms/djangoapps/learner_dashboard/programs.py#L87



## Additional information



## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->