### PR TITLE
feat: Add course_home api multitenant restriction, based on the curre…

### DIFF
--- a/eox_tenant/middleware.py
+++ b/eox_tenant/middleware.py
@@ -40,7 +40,10 @@ class MicrositeCrossBrandingFilterMiddleware(MiddlewareMixin):
         microsite, but it is not the current microsite
         """
         path = request.path_info
-        regex_path_match = re.compile('/courses/{}/'.format(settings.COURSE_ID_PATTERN))
+        restricted_courses_pattern = "|".join(settings.EOX_TENANT_RESTRICTED_COURSE_PATTERNS)
+        regex_path_match = re.compile(
+            f'/({restricted_courses_pattern})/{settings.COURSE_ID_PATTERN}',
+        )
         matched_regex = regex_path_match.match(path)
 
         # If there is no match, then we are not in a ORG-restricted area

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -67,3 +67,8 @@ def plugin_settings(settings):
         settings.MAKO_TEMPLATE_DIRS_BASE.insert(0, path(__file__).abspath().dirname().dirname() / 'templates')
     except AttributeError:
         pass
+
+    settings.EOX_TENANT_RESTRICTED_COURSE_PATTERNS = [
+        "courses",
+        "(api/course_home/.+)",
+    ]


### PR DESCRIPTION
## Description

Course Home API has the following endpoints

![image](https://user-images.githubusercontent.com/36200299/214188142-5b4a4752-1d9a-4621-99fd-506f7c87fe60.png)

Some of them depends on the course id, however if someone tries to access the result will be successful if the course exists, no matter if the course doesn't belong to the current site, so this pr copies current validations of `/courses/<course-id>` to  `/api/course_home/something/,course-id>` in orderr to return  404 if the course doesn't belong to the current site.

## Testing instructions

1. Go to any endpoint, for example, /api/course_home/course_metadata/<your course id>
2. Then go to a different tenant, that tenant must have the setting course_org_filter with a different value from the course org, the result should be a 404 error.

### Example of configuration:

Tenant 1
```
{
    "course_org_filter": "edx"
}
```
Tenant 2
```
{
    "course_org_filter": "test"
}
```
if  course_id is course-v1:edx+CS101+2022_T4 the api result will be visible in tenant 1 and tenant 2 will return 404.
