### PR TITLE
ci: add open-release/* branches to github workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'open-release/*'
 
 jobs:
   Running-test:


### PR DESCRIPTION
## Description

Run tests with open-release/* branches, this is required since NELP has a custom branch called [open-release/mango.nelp](https://github.com/eduNEXT/eox-tenant/tree/open-release/mango.nelp)

## Testing instructions

Make a PR against open-release/mango.nelp, all tests should run.

