### PR TITLE
ci: add open-release/* branches to github workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'open-release/*'
 
 jobs:
   Running-test:


### PR DESCRIPTION
## Description

Back port of https://github.com/eduNEXT/eox-tenant/pull/168
