### PR TITLE
feat: add course_home api pattern to MicrositeCrossBrandingFilterMidd…

### DIFF
--- a/eox_tenant/middleware.py
+++ b/eox_tenant/middleware.py
@@ -40,7 +40,10 @@ class MicrositeCrossBrandingFilterMiddleware(MiddlewareMixin):
         microsite, but it is not the current microsite
         """
         path = request.path_info
-        regex_path_match = re.compile('/courses/{}/'.format(settings.COURSE_ID_PATTERN))
+        restricted_courses_pattern = "|".join(settings.EOX_TENANT_RESTRICTED_COURSE_PATTERNS)
+        regex_path_match = re.compile(
+            f'/({restricted_courses_pattern})/{settings.COURSE_ID_PATTERN}',
+        )
         matched_regex = regex_path_match.match(path)
 
         # If there is no match, then we are not in a ORG-restricted area

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -66,3 +66,8 @@ def plugin_settings(settings):
         settings.MAKO_TEMPLATE_DIRS_BASE.insert(0, path(__file__).abspath().dirname().dirname() / 'templates')
     except AttributeError:
         pass
+
+    settings.EOX_TENANT_RESTRICTED_COURSE_PATTERNS = [
+        "courses",
+        "(api/course_home/.+)",
+    ]


### PR DESCRIPTION
## Description
There are three main changes and the main reason is that the MFEs use the course_home api to get the course data

1. Middleware will check `/courses/<course-id>` and `/api/course_home/*/<course-id>` by default instead of just `/courses/<course-id>`
2. Restricted patterns are now configurable, if someone wants to restrict another path, they can add a setting like this in the tenant config:
```
EOX_TENANT_RESTRICTED_COURSE_PATTERNS = [
        "courses",
        "(api/course_home/.+)",
        "(my-custon-path/courses)",
    ]
``` 
keep in mind this middleware works with course-id patterns, so the custom path is something like my-custon-path/courses/<course-id>, if you want to remove restrictions
``` 
EOX_TENANT_RESTRICTED_COURSE_PATTERNS = [
        "courses",
    ]
``` 
3. common course path were added to the testings cases

## Testing instructions

1. you need to tenants with different course_org_filter values
 
Example:

tenant config A
``` 
{
    "course_org_filter": "edx"
}
``` 
tenant config B
``` 
{
    "course_org_filter": "test"
}
``` 
2. create a course in any tenant organization, following the example, create a course with `test` or `edx `organization
3. Go to course and course_home page
Example:
`tenant-A-domain/courses/<course-id>`  or` tenant-B-domain/courses/<course-id>`
`tenant-A-domain/api/course_home/something/<course-id>`  or` tenant-B-domain/api/course_home/something/<course-id>`

if the course was created with tenant A organization,and then  you try to access trough tenant A, the result will be the default result, but if you try to access the same course trough tenant B the result will be  404

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits
