### PR TITLE
refactor!(DS-434): avoid registering models in services different than LMS

### DIFF
--- a/eox_tenant/admin.py
+++ b/eox_tenant/admin.py
@@ -281,6 +281,7 @@ class TenantOrganizationAdmin(admin.ModelAdmin):
 
         return queryset, _
 
+
 if getattr(settings, "SERVICE_VARIANT", None) == "lms":
     admin.site.register(Microsite, MicrositeAdmin)
     admin.site.register(TenantConfig, TenantConfigAdmin)

--- a/eox_tenant/admin.py
+++ b/eox_tenant/admin.py
@@ -4,6 +4,7 @@ Django admin page for microsite model
 from itertools import chain
 
 from django import forms
+from django.conf import settings
 from django.contrib import admin
 from django.db import models
 from django.urls import reverse
@@ -280,8 +281,8 @@ class TenantOrganizationAdmin(admin.ModelAdmin):
 
         return queryset, _
 
-
-admin.site.register(Microsite, MicrositeAdmin)
-admin.site.register(TenantConfig, TenantConfigAdmin)
-admin.site.register(Route, RouteAdmin)
-admin.site.register(TenantOrganization, TenantOrganizationAdmin)
+if getattr(settings, "SERVICE_VARIANT", None) == "lms":
+    admin.site.register(Microsite, MicrositeAdmin)
+    admin.site.register(TenantConfig, TenantConfigAdmin)
+    admin.site.register(Route, RouteAdmin)
+    admin.site.register(TenantOrganization, TenantOrganizationAdmin)


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description
This PR adds an extra check before registering eox-tenant models into the Django Admin page. We aim to only register those models in the LMS service.

## Testing instructions

1. Install this version of the plugin in your development environment. In the LMS/CMS
2. Then restart services
3. Check both admins, the multitenancy models should be registered just in the LMS.

## Additional information
This PR solves: https://github.com/eduNEXT/eox-tenant/issues/154 by removing any modifications from the studio admin page. I tested this in olive & nutmeg.


## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->