### PR TITLE
fix: bypass load permission if migrations not completed

### DIFF
--- a/eox_tenant/api/v1/permissions.py
+++ b/eox_tenant/api/v1/permissions.py
@@ -4,6 +4,7 @@ Permission for eox_tenant api v1.
 from django.conf import settings
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ImproperlyConfigured
 from django.db.utils import ProgrammingError
 from rest_framework import exceptions, permissions
 
@@ -13,19 +14,22 @@ def load_permissions():
     Helper method to load a custom permission on DB that will be
     used to give access to the eox-tenant API.
     """
-    if settings.EOX_TENANT_LOAD_PERMISSIONS:
-        try:
-            content_type = ContentType.objects.get_for_model(User)
-            Permission.objects.get_or_create(
-                codename='can_call_eox_tenant',
-                name='Can access eox-tenant API',
-                content_type=content_type,
-            )
-        except ProgrammingError:
-            # This code runs when the app is loaded, if a migration has not been
-            # done a ProgrammingError exception is raised.
-            # we are bypassing those cases to let migrations run smoothly.
-            pass
+    try:
+        if settings.EOX_TENANT_LOAD_PERMISSIONS:
+            try:
+                content_type = ContentType.objects.get_for_model(User)
+                Permission.objects.get_or_create(
+                    codename='can_call_eox_tenant',
+                    name='Can access eox-tenant API',
+                    content_type=content_type,
+                )
+            except ProgrammingError:
+                # This code runs when the app is loaded, if a migration has not been
+                # done a ProgrammingError exception is raised.
+                # we are bypassing those cases to let migrations run smoothly.
+                pass
+    except ImproperlyConfigured:
+        pass
 
 
 class EoxTenantAPIPermission(permissions.BasePermission):


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This MR fixes tutor build failure due to permissions file being loaded before migrations. The fix is inspired by https://github.com/eduNEXT/eox-tenant/pull/145

## Testing instructions

Install this plugin in tutor and run `tutor images build openedx`, it will fail with database `ImproperlyConfigured` error. Update your local copy of plugin with this change and run build, it should work.


## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->