### PR TITLE
(DS-451)feat: adds TenantAwareLinkRenderStarted filter

### DIFF
--- a/eox_tenant/__init__.py
+++ b/eox_tenant/__init__.py
@@ -1,4 +1,4 @@
 """
 Init for eox-tenant.
 """
-__version__ = '11.7.0'
+__version__ = '11.8.0'

--- a/eox_tenant/filters/README.rst
+++ b/eox_tenant/filters/README.rst
@@ -13,8 +13,12 @@ Filters steps list:
 -------------------
 
 * `FilterUserCourseEnrollmentsByTenant`_: Filters the course enrollments of a user from the tenant site where the request is made.
+* `FilterRenderCertificatesByOrg`_: Stop certificate generation process raising a exception if course org is different to tenant orgs.
+* `TenantAwareLinksFromStudio`_: Filter especific tenant aware link form Studio to the LMS.
 
-.. _FilterUserCourseEnrollmentsByTenant: ./pipeline.py#L9
+.. _FilterUserCourseEnrollmentsByTenant: ./pipeline.py#L12
+.. _FilterRenderCertificatesByOrg: ./pipeline.py#L35
+.. _TenantAwareLinksFromStudio: ./pipeline.py#L63
 
 How to add a new Filter Step:
 -----------------------------

--- a/eox_tenant/filters/pipeline.py
+++ b/eox_tenant/filters/pipeline.py
@@ -2,6 +2,7 @@
 The pipeline module defines custom Filters functions that are used in openedx-filters.
 """
 from openedx_filters import PipelineStep
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx_filters.learning.filters import CertificateRenderStarted
 
 from eox_tenant.organizations import get_organizations
@@ -57,3 +58,26 @@ class FilterRenderCertificatesByOrg(PipelineStep):
         raise CertificateRenderStarted.RenderAlternativeInvalidCertificate(
             "You can't generate a certificate from this site.",
         )
+
+
+class FilterTenantAwareLinksFromStudio(PipelineStep):
+    """
+    Filter tenant aware links from Studio.
+    """
+
+    def run_filter(self, context, org, val_name, default):  # pylint: disable=arguments-differ
+        """
+        Filter especific tenant aware link form Studio to the LMS.
+        Example Usage:
+        Add the following configurations to you configuration file
+            "OPEN_EDX_FILTERS_CONFIG": {
+                "org.openedx.learning.tenant_aware_link.render.started.v1": {
+                    "fail_silently": false,
+                    "pipeline": [
+                        "eox_tenant.filters.pipeline.FilterTenantAwareLinksFromStudio"
+                    ]
+                }
+            }
+        """
+        lms_root = configuration_helpers.get_value_for_org(org, val_name, default)
+        return {"context": lms_root}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 11.7.0
+current_version = 11.8.0
 commit = False
 tag = False
 


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR adds a custom filter pipeline to get LMS_ROOT_URL value for org from tenant site.

The idea is including some changes in _openedx-filters_ and _edx-platform_ repositories to anyone implement the filter function, and one clear example to use is this custom pipeline on eox-tenant plugin.

**Dependencies**:
- openedx/edx-platfom: https://github.com/openedx/edx-platform/pull/32014
- openedx/openedx-filters: https://github.com/openedx/openedx-filters/pull/77
- 
## Testing instructions

1. In a Nutmeg or Olive environment, install the plugin with the changes in [openedx/edx-platform](https://github.com/openedx/edx-platform/pull/32014) and [openedx/openedx-filters](https://github.com/openedx/openedx-filters/pull/77) branches. Use the [Tutor instructions](https://docs.tutor.overhang.io/configuration.html#installing-extra-requirements-from-private-repositories) to install the eox-tenant django plugin with the changes in this branch.

```yml
# Clone repo
git clone git+https://github.com/eduNEXT/eox-tenant.git "$(tutor config printroot)/env/build/openedx/requirements/"
# Change branch
git checkout JDB/add_tenant_aware_filter
# Adds path to private.txt
echo "./eox-tenant" >> "$(tutor config printroot)/env/build/openedx/requirements/private.txt"
```

2. Create a Tenant and import a certificate course (You need to create a tenant for Studio too). Go on to create sites: http://lms.nutmeg.edunext.link:8000/admin/eox_tenant/tenantconfig/

3. Add the following configurations to your configuration site and Studio tenant.
```json
"OPEN_EDX_FILTERS_CONFIG": {
                "org.openedx.learning.tenant_aware_link.render.started.v1": {
                    "fail_silently": false,
                    "pipeline": [
                        "eox_tenant.filters.pipeline.FilterTenantAwareLinksFromStudio"
                    ]
                }
            },
```
4. Now Go to Content -> course outline, click on the “View live” button, which should direct you to the URL of the specific tenant (what is configured in SITE_NAME)
5. Go to Settings-> Schedule & Details, click on the “Course Summary Page” link, which should direct you to the URL of the specific tenant
6. Verify that the link of the "Invite your students" button in the body refers to the URL of the specific tenant
7. Also check for a link to a course summary below the “course overview” text box.
8. Go to Content -> Files & uploads, verify the absolute links of any asset (In the Web button), which should lead to the URL of the specific tenant
9. Go to Settings -> Certificates and click on the “Preview certificate” button, which should point to the URL of the specific tenant. It doesn't matter if what it loads isn't pretty, as long as it's the correct URL.

## Additional information

- Test cases file: https://docs.google.com/document/d/1lWlC1_xqO308oHNH0F4fOdyV3uBlVte0wQC6UOa_3SE/edit?usp=sharing

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->