### PR TITLE
feat: having released_languages tenant and site aware DS-553

### DIFF
--- a/eox_tenant/edxapp_wrapper/backends/dark_lang_middleware_o_test_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/dark_lang_middleware_o_test_v1.py
@@ -1,0 +1,9 @@
+"""
+DarkLangMiddleware Backend for tests.
+"""
+from unittest.mock import MagicMock
+
+
+def get_dark_lang_middleware():
+    """Backend to get the DarkLangMiddleware from openedx."""
+    return MagicMock()

--- a/eox_tenant/edxapp_wrapper/backends/dark_lang_middleware_o_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/dark_lang_middleware_o_v1.py
@@ -1,4 +1,8 @@
-from openedx.core.djangoapps.dark_lang.middleware import DarkLangMiddleware
+"""
+DarkLangMiddleware Backend.
+"""
+from openedx.core.djangoapps.dark_lang.middleware import DarkLangMiddleware  # pylint: disable=import-error
+
 
 def get_dark_lang_middleware():
     """Backend to get the DarkLangMiddleware from openedx."""

--- a/eox_tenant/edxapp_wrapper/backends/dark_lang_middleware_o_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/dark_lang_middleware_o_v1.py
@@ -1,0 +1,5 @@
+from openedx.core.djangoapps.dark_lang.middleware import DarkLangMiddleware
+
+def get_dark_lang_middleware():
+    """Backend to get the DarkLangMiddleware from openedx."""
+    return DarkLangMiddleware

--- a/eox_tenant/edxapp_wrapper/dark_lang_middleware.py
+++ b/eox_tenant/edxapp_wrapper/dark_lang_middleware.py
@@ -1,0 +1,11 @@
+""" Backend abstraction. """
+from importlib import import_module
+
+from django.conf import settings
+
+
+def get_dark_lang_middleware(*args, **kwargs):
+    """ Get DarkLangMiddleware. """
+    backend_function = settings.DARK_LANG_MIDDLEWARE
+    backend = import_module(backend_function)
+    return backend.get_dark_lang_middleware(*args, **kwargs)

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -48,6 +48,7 @@ def plugin_settings(settings):
     settings.EDXMAKO_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.edxmako_l_v1'
     settings.UTILS_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.util_h_v1'
     settings.CHANGE_DOMAIN_DEFAULT_SITE_NAME = "stage.edunext.co"
+    settings.DARK_LANG_MIDDLEWARE = 'eox_tenant.edxapp_wrapper.backends.dark_lang_middleware_o_v1'
     settings.EOX_TENANT_LOAD_PERMISSIONS = True
     settings.EOX_TENANT_APPEND_LMS_MIDDLEWARE_CLASSES = False
     settings.USE_EOX_TENANT = False

--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -33,6 +33,7 @@ GET_SITE_CONFIGURATION_MODULE = 'eox_tenant.edxapp_wrapper.backends.site_configu
 GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_test_v1'
 EOX_TENANT_USERS_BACKEND = 'eox_tenant.edxapp_wrapper.backends.users_test_v1'
 EOX_TENANT_BEARER_AUTHENTICATION = 'eox_tenant.edxapp_wrapper.backends.bearer_authentication_test_v1'
+DARK_LANG_MIDDLEWARE = 'eox_tenant.edxapp_wrapper.backends.dark_lang_middleware_o_test_v1'
 
 COURSE_KEY_PATTERN = r'(?P<course_key_string>[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'
 COURSE_ID_PATTERN = COURSE_KEY_PATTERN.replace('course_key_string', 'course_id')

--- a/eox_tenant/tenant_aware_functions/released_languages.py
+++ b/eox_tenant/tenant_aware_functions/released_languages.py
@@ -1,0 +1,38 @@
+from collections import namedtuple
+
+from django.conf import settings
+
+Language = namedtuple('Language', 'code name')
+
+def tenant_languages():
+    """Retrieve the list of released languages by tenant.
+
+    Constructs a list of Language tuples by intersecting the
+    list of valid language tuples with the list of released
+    language codes.
+
+    Returns:
+       list of Language: Languages in which full translations are available.
+
+    Example:
+
+        >>> print released_languages()
+        [Language(code='en', name=u'English'), Language(code='fr', name=u'Français')]
+
+    """
+    released_languages = getattr(settings, "released_languages", "")
+    released_language_codes = [lang.lower().strip() for lang in released_languages.split(',')]
+    default_language_code = settings.LANGUAGE_CODE
+
+    if default_language_code not in released_language_codes:
+        released_language_codes.append(default_language_code)
+
+    released_language_codes.sort()
+
+    # Intersect the list of valid language tuples with the list
+    # of released language codes
+    return [
+        Language(language_info[0], language_info[1])
+        for language_info in settings.LANGUAGES
+        if language_info[0] in released_language_codes
+    ]

--- a/eox_tenant/tenant_aware_functions/released_languages.py
+++ b/eox_tenant/tenant_aware_functions/released_languages.py
@@ -1,8 +1,12 @@
+"""
+Site/Tenant aware languages filter.
+"""
 from collections import namedtuple
 
 from django.conf import settings
 
 Language = namedtuple('Language', 'code name')
+
 
 def tenant_languages():
     """Retrieve the list of released languages by tenant.

--- a/eox_tenant/tenant_wise/__init__.py
+++ b/eox_tenant/tenant_wise/__init__.py
@@ -10,8 +10,8 @@ import six
 from django.conf import settings
 
 from eox_tenant.constants import LMS_ENVIRONMENT
-from eox_tenant.tenant_wise.proxies import TenantSiteConfigProxy, DarkLangMiddlewareProxy
 from eox_tenant.tenant_aware_functions.released_languages import tenant_languages
+from eox_tenant.tenant_wise.proxies import DarkLangMiddlewareProxy, TenantSiteConfigProxy
 
 
 def load_tenant_wise_overrides():

--- a/eox_tenant/tenant_wise/__init__.py
+++ b/eox_tenant/tenant_wise/__init__.py
@@ -10,7 +10,8 @@ import six
 from django.conf import settings
 
 from eox_tenant.constants import LMS_ENVIRONMENT
-from eox_tenant.tenant_wise.proxies import TenantSiteConfigProxy
+from eox_tenant.tenant_wise.proxies import TenantSiteConfigProxy, DarkLangMiddlewareProxy
+from eox_tenant.tenant_aware_functions.released_languages import tenant_languages
 
 
 def load_tenant_wise_overrides():
@@ -31,6 +32,18 @@ def load_tenant_wise_overrides():
                 model='SiteConfiguration',
                 proxy=TenantSiteConfigProxy
             )
+
+            if settings.FEATURES.get("EDNX_SITE_AWARE_LOCALE", False):
+                set_as_proxy(
+                    modules='openedx.core.djangoapps.lang_pref.api',
+                    model='released_languages',
+                    proxy=tenant_languages
+                )
+                set_as_proxy(
+                    modules='openedx.core.djangoapps.dark_lang.middleware',
+                    model='DarkLangMiddleware',
+                    proxy=DarkLangMiddlewareProxy
+                )
 
 
 def set_as_proxy(modules, model, proxy):

--- a/eox_tenant/tenant_wise/proxies.py
+++ b/eox_tenant/tenant_wise/proxies.py
@@ -8,10 +8,9 @@ from itertools import chain
 import six
 from django.conf import settings
 from django.core.cache import cache
-from eox_tenant.edxapp_wrapper.dark_lang_middleware import \
-    get_dark_lang_middleware
-from eox_tenant.edxapp_wrapper.site_configuration_module import \
-    get_site_configuration_models
+
+from eox_tenant.edxapp_wrapper.dark_lang_middleware import get_dark_lang_middleware
+from eox_tenant.edxapp_wrapper.site_configuration_module import get_site_configuration_models
 from eox_tenant.models import Microsite, TenantConfig, TenantOrganization
 from eox_tenant.utils import clean_serializable_values
 
@@ -215,12 +214,12 @@ class DarkLangMiddlewareProxy(DarkLangMiddleware):
         """
         Current list of released languages from settings.
         """
-        
+
         language_options = getattr(settings, "released_languages", "")
         if settings.LANGUAGE_CODE not in language_options:
             language_options.append(settings.LANGUAGE_CODE)
         return language_options
-    
+
     def process_request(self, request):
         """
         This will be run when you do a request, and prevent user from requesting un-released languages.

--- a/eox_tenant/tenant_wise/proxies.py
+++ b/eox_tenant/tenant_wise/proxies.py
@@ -215,7 +215,8 @@ class DarkLangMiddlewareProxy(DarkLangMiddleware):
         Current list of released languages from settings.
         """
 
-        language_options = getattr(settings, "released_languages", "")
+        get_language_options = getattr(settings, "released_languages", "")
+        language_options = [lang.lower().strip() for lang in get_language_options.split(',')]
         if settings.LANGUAGE_CODE not in language_options:
             language_options.append(settings.LANGUAGE_CODE)
         return language_options


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description
This PR extract LC-V2 from the platform to eox-tenant.

LC-V2 allows you to have released_languages site aware in: `openedx/core/djangoapps/lang_pref/api.py`, `openedx/core/djangoapps/dark_lang/middleware.py`. And set a default value to HTTP_ACCEPT_LANGUAGE.

More context: [LC-V2 Doc](https://docs.google.com/document/d/1EO5aDX8CrsDRwdlqtu-VE5SduQmQ3xYLpShfOdhXYqQ/edit?usp=sharing)

## Testing instructions
### SetUp
- You need to have a Tutor environment with eox-tenant installed with this version.
- You need to add some settings for eox-tenant and the selectors to work (you can add it in env/apps/openedx/config/lms.env.yml and in env/apps/openedx/config/cms.env.yml):
    - USE_EOX_TENANT: true
    - Y en FEATURES:
        - EDNX_SITE_AWARE_LOCALE: true
        - SHOW_FOOTER_LANGUAGE_SELECTOR: true
        - SHOW_HEADER_LANGUAGE_SELECTOR: true
 - Create a Tenant A with this config:
```
 {
    "EDNX_USE_SIGNAL": true,
    "PLATFORM_NAME": "Tenant A",
    "SITE_NAME": "tenant-a.local.overhang.io:8000",
    "course_org_filter": [
        "edX"
    ],
    "released_languages": "en, es-419, pt-BR, ru, da, ar, it",
    "LANGUAGE_CODE":"es-419"
}
```
 - Create a Tenant B:
```
 {
    "EDNX_USE_SIGNAL": true,
    "PLATFORM_NAME": "Tenant B",
    "SITE_NAME": "tenant-b.local.overhang.io:8000",
    "course_org_filter": [
        "edX"
    ],
    "released_languages": "en, ar, fr"
}
```
- Create a tenant with the Studio route:
```
{
    "EDNX_USE_SIGNAL": true,
    "LANGUAGE_CODE": "pt-BR",
    "PLATFORM_NAME": "Studio Test",
    "SITE_NAME": "studio.local.overhang.io:8001",
    "released_languages": "en, es-419, pt-BR, ru, da, ar, it"
}
```
### How to test it

- Visit tenant-a.local.overhang.io:8000 and tenant-b.local.overhang.io:8000 and you are going to see different languages in the header and footer dropdown, depending on release_languages config (Test the API section).
- Enter studio.local.overhang.io:8001 and see the dropdown options. (Testing the Studio)
- In your terminal run: `curl http://tenant-a.local.overhang.io:8000 -s 2>&1 | head -n 15` and you should see the LANGUAGE_CODE defined by site, for example in tenant-a is es-419. (Testing the default HTTP, and also the middleware)

## Additional information
### Implementation
- This adds two "proxies", the first one to override the API and another to override the middleware and set a default value to HTTP_ACCEPT_LANGUAGE.
- We create a backend to inherit from DarkLangMiddleware.

### About this feature
- If you are not login you can change the lang, but you are not going to maintain that lang (the middleware always reset to the LANGUAGE_CODE)
- If you are login you can change the lang with the footer and maintain that config. Also, you can edit the lang in your account settings with http://tenant-a.local.overhang.io:8000/account/settings
- Another thing is if you used http://tenant-a.local.overhang.io:8000/update_lang/ that has the maximum priority. If you want to try the footer and header feature for languages I recommend not setting the lang with /update_lang/ or if you already have settled you can reset the configuration in that update page.

## Checklist for Merge

- [ ] Updated documentation
- [x] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->