### PR TITLE
feat: separate studio config and handler

### DIFF
--- a/eox_tenant/apps.py
+++ b/eox_tenant/apps.py
@@ -37,7 +37,7 @@ class EdunextOpenedxExtensionsTenantConfig(AppConfig):
                 'relative_path': 'signals',
                 'receivers': [
                     {
-                        'receiver_func_name': 'start_tenant',
+                        'receiver_func_name': 'start_lms_tenant',
                         'signal_path': 'django.core.signals.request_started',
                     },
                     {
@@ -53,7 +53,7 @@ class EdunextOpenedxExtensionsTenantConfig(AppConfig):
                         'signal_path': 'celery.signals.before_task_publish',
                     },
                     {
-                        'receiver_func_name': 'start_async_tenant',
+                        'receiver_func_name': 'start_async_lms_tenant',
                         'signal_path': 'celery.signals.task_prerun',
                     },
                     {
@@ -74,7 +74,7 @@ class EdunextOpenedxExtensionsTenantConfig(AppConfig):
                 'relative_path': 'signals',
                 'receivers': [
                     {
-                        'receiver_func_name': 'start_tenant',
+                        'receiver_func_name': 'start_studio_tenant',
                         'signal_path': 'django.core.signals.request_started',
                     },
                     {
@@ -82,7 +82,7 @@ class EdunextOpenedxExtensionsTenantConfig(AppConfig):
                         'signal_path': 'celery.signals.before_task_publish',
                     },
                     {
-                        'receiver_func_name': 'start_async_tenant',
+                        'receiver_func_name': 'start_async_studio_tenant',
                         'signal_path': 'celery.signals.task_prerun',
                     },
                 ],

--- a/eox_tenant/constants.py
+++ b/eox_tenant/constants.py
@@ -2,3 +2,6 @@
 from django.conf import settings
 
 LMS_ENVIRONMENT = getattr(settings, "SERVICE_VARIANT", None) == "lms"
+CMS_ENVIRONMENT = getattr(settings, "SERVICE_VARIANT", None) == "cms"
+LMS_CONFIG_COLUMN = "lms_configs"
+CMS_CONFIG_COLUMN = "studio_configs"

--- a/eox_tenant/models.py
+++ b/eox_tenant/models.py
@@ -11,6 +11,8 @@ from django.db import connection, models
 from django.utils.translation import gettext_lazy as _
 from jsonfield.fields import JSONField
 
+from eox_tenant.constants import CMS_CONFIG_COLUMN, LMS_CONFIG_COLUMN
+
 
 class TenantOrganization(models.Model):
     """
@@ -150,8 +152,8 @@ class TenantConfigManager(models.Manager):
                 configurations = {
                     "id": row[0],
                     "external_key": row[1],
-                    "lms_configs": json.loads(row[2]),
-                    "studio_configs": json.loads(row[3]),
+                    LMS_CONFIG_COLUMN: json.loads(row[2]),
+                    CMS_CONFIG_COLUMN: json.loads(row[3]),
                     "theming_configs": json.loads(row[4]),
                     "meta": json.loads(row[5]),
                 }
@@ -193,7 +195,7 @@ class TenantConfig(models.Model):
         return org_filter
 
     @classmethod
-    def get_configs_for_domain(cls, domain):
+    def get_configs_for_domain(cls, domain, config_key):
         """
         Get edxapp configuration using a domain. There is a compat layer to support microsite until
         deprecation.
@@ -204,7 +206,7 @@ class TenantConfig(models.Model):
         config = TenantConfig.objects.get_configurations(domain=domain)
 
         if config:
-            return config["lms_configs"], config["external_key"]
+            return config[config_key], config["external_key"]
 
         return {}, None
 

--- a/eox_tenant/receivers_helpers.py
+++ b/eox_tenant/receivers_helpers.py
@@ -6,12 +6,13 @@ from django.conf import settings
 from eox_tenant.models import Microsite, TenantConfig
 
 
-def get_tenant_config_by_domain(domain):
+def get_tenant_config_by_domain(domain, config_key):
     """
     Reach for the configuration for a given domain.
 
     **Arguments**
         domain: String parameter.
+        config_key: Config column name.
 
     **Returns**
         configurations: dict
@@ -20,7 +21,7 @@ def get_tenant_config_by_domain(domain):
     if not getattr(settings, 'USE_EOX_TENANT', False):
         return {}, None
 
-    configurations, external_key = TenantConfig.get_configs_for_domain(domain)
+    configurations, external_key = TenantConfig.get_configs_for_domain(domain, config_key)
 
     if configurations and external_key:
         return configurations, external_key

--- a/eox_tenant/test/test_receivers_helpers.py
+++ b/eox_tenant/test/test_receivers_helpers.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 
 from django.test import TestCase
 
+from eox_tenant.constants import CMS_CONFIG_COLUMN, LMS_CONFIG_COLUMN
 from eox_tenant.models import Microsite, Route, TenantConfig
 from eox_tenant.receivers_helpers import get_tenant_config_by_domain
 
@@ -34,7 +35,9 @@ class ReceiversHelpersTests(TestCase):
                 "course_org_filter": ["test5-org", "test1-org"],
                 "value-test": "Hello-World3",
             },
-            studio_configs={},
+            studio_configs={
+                "value-test": "studio",
+            },
             theming_configs={},
             meta={},
         )
@@ -44,11 +47,11 @@ class ReceiversHelpersTests(TestCase):
             config=TenantConfig.objects.get(external_key="tenant-key1"),
         )
 
-    def test_tenant_get_config_by_domain(self):
+    def test_tenant_get_lms_config_by_domain(self):
         """
         Test to get the configuration and external key for a given domain.
         """
-        configurations, external_key = get_tenant_config_by_domain("domain1")
+        configurations, external_key = get_tenant_config_by_domain("domain1", LMS_CONFIG_COLUMN)
 
         self.assertEqual(external_key, "tenant-key1")
         self.assertDictEqual(
@@ -59,12 +62,34 @@ class ReceiversHelpersTests(TestCase):
             },
         )
 
-        configurations, external_key = get_tenant_config_by_domain("domain2")
+    def test_tenant_get_studio_config_by_domain(self):
+        """
+        Test to get the configuration and external key for a given domain.
+        """
+        configurations, external_key = get_tenant_config_by_domain("domain1", CMS_CONFIG_COLUMN)
+
+        self.assertEqual(external_key, "tenant-key1")
+        self.assertDictEqual(
+            configurations,
+            {
+                "value-test": "studio",
+            },
+        )
+
+    def test_no_tenant_get_config_by_domain(self):
+        """
+        Test to get the configuration and external key for a non-existent domain.
+        """
+        configurations, external_key = get_tenant_config_by_domain("domain2", LMS_CONFIG_COLUMN)
 
         self.assertEqual(external_key, None)
         self.assertDictEqual(configurations, {})
 
-        configurations, external_key = get_tenant_config_by_domain("first.test.prod.edunext")
+    def test_microsite_get_config_by_domain(self):
+        """
+        Test to get the configuration and external key for a given domain from Microsite table.
+        """
+        configurations, external_key = get_tenant_config_by_domain("first.test.prod.edunext", LMS_CONFIG_COLUMN)
 
         self.assertEqual(external_key, "test_fake_key")
         self.assertDictEqual(


### PR DESCRIPTION
## Description

Makes use of `studio_configs` field from `TenantConfig` table to keep studio configuration separate from LMS configs. It achieves the separation by having separate signal handlers for LMS and studio.

**This is required** due to conflicts between lms and studio settings. For example, repopulating `third_party_auth` plugin overrides few settings, one of which is `SOCIAL_AUTH_STRATEGY`. It needs to be set to `auth_backends.strategies.EdxDjangoStrategy` for studio and `common.djangoapps.third_party_auth.strategy.ConfigurationModelStrategy` for lms for third_party auth to work smoothly.

## Testing instructions

* Setup nutmeg or master devstack.
* Install this plugin in both studio and lms.
* Add a new tenant, for example, lacolhost.com (points to localhost), so you can visit lacolhost.com:18000 to access LMS and lacolhost.com:18010 to access studio.
* Set different `PLATFORM_NAME` in both `lms_configs` and `studio_configs` field for an external key and link it to lacolhost.com route via `Routes` table.
* Visit lacolhost.com:18000 and lacolhost.com:18010 and verify that different `PLATFORM_NAME` is set.

<summary>
Screenshots:
<details>

![image](https://github.com/eduNEXT/eox-tenant/assets/10894099/93fe7dfa-1c00-4b5f-b9df-27208ae50df2)

![image](https://github.com/eduNEXT/eox-tenant/assets/10894099/710cd901-462c-455d-ae97-c52cad3a5ca4)
</details>
</summary>


## Checklist for Merge

- [x] Tested in a remote environment
- [x] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits
