### PR TITLE
feat: add openedx commitlint.config.js

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,32 @@
+// See: https://commitlint.js.org/#/reference-configuration for details
+// on the configuration file
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+
+  rules: {
+    'type-enum':
+      [2, 'always', [
+        'revert', 'feat', 'fix', 'perf', 'docs', 'test', 'build', 'refactor', 'style', 'chore', 'temp', 'ci',
+      ]],
+
+    // Default rules we want to suppress. The available list of rules can be
+    // found in https://commitlint.js.org/#/reference-rules
+    'body-leading-blank': [0, "always"],
+    'body-max-line-length': [0, "always"],
+    'footer-max-line-length': [0, "always"],
+    'footer-leading-blank': [0, "always"],
+    'subject-case': [0, "always", []],
+    'subject-full-stop': [0, "never", '.'],
+  },
+
+  ignores: [
+    // Allow GitHub revert messages, like:
+    //    Revert "introduce a bug"
+    //    Revert "introduce a bug" (#1234)
+    message => /^Revert ".*"( \(#\d+\))?/.test(message),
+
+    // BTW: commitlint has a built-in list of ignores which are also applied.
+    // Those include the typical "Merged" messages, so those are implicitly ignored:
+    // https://github.com/conventional-changelog/commitlint/blob/master/%40commitlint/is-ignored/src/defaults.ts
+  ],
+};


### PR DESCRIPTION

<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This adds openedx commit lintern rules.

This is inspired by the following PR:
https://github.com/eduNEXT/shipyard-infrastructure/pull/25/files

This fixes the footer long chars error.

This is mostly based on: 
https://github.com/openedx/edx-lint/blob/master/commitlint.config.js

In particular, limiting the length of a line in the commit body might be detrimental when including external links.




## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->