### PR TITLE
fix: allow using boolean as values in tenant configs when getting settings by organization

### DIFF
--- a/eox_tenant/models.py
+++ b/eox_tenant/models.py
@@ -216,7 +216,7 @@ class TenantConfig(models.Model):
         for result in results:
             value = result.lms_configs.get(val_name)
 
-            if value:
+            if value is not None:
                 return value
 
         return None

--- a/eox_tenant/tenant_wise/proxies.py
+++ b/eox_tenant/tenant_wise/proxies.py
@@ -155,7 +155,7 @@ class TenantSiteConfigProxy(SiteConfigurationModels.SiteConfiguration):
 
         result = TenantConfig.get_value_for_org(org, val_name)
 
-        if result:
+        if result is not None:
             cls.set_key_to_cache(cache_key, result)
             return result
 


### PR DESCRIPTION
## Description

This PR is created for **a necessity arisen in the [PR #808 from edunext-platform](https://github.com/eduNEXT/edunext-platform/pull/808)** and allows using boolean types as values because when some tenant properties have a value `False` or `True`, this is used to run two conditionals. e.g. if a tenant setting `ENABLE_COURSE_AUTHORING_MFE` has a value `False`, even though we want to send the value `False`, the conditional is skipped and is returned a None instead of `False` 

## Testing instructions

At this moment the useful way to test this PR would be running the [PR #808 from edunext-platform](https://github.com/eduNEXT/edunext-platform/pull/808) 