### PR TITLE
feat: add route domain to proxy the site `domain`

### DIFF
--- a/eox_tenant/middleware.py
+++ b/eox_tenant/middleware.py
@@ -112,4 +112,5 @@ class CurrentSiteMiddleware(MiddlewareMixin):
         """
         site = get_current_site(request)
         site.configuration = TenantSiteConfigProxy()
+        site.domain = getattr(settings, 'EDNX_TENANT_DOMAIN', site.domain)
         request.site = site


### PR DESCRIPTION

<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This add the route domain if the tenant has tenant route a associated. This also avoid the creation of a site record with the same domain of a route created.

Migration pr of  https://github.com/eduNEXT/eox-tenant/pull/162

