### PR TITLE
Correcting user restriction behavior by sign up source in eox-tenant

### DIFF
--- a/eox_tenant/edxapp_wrapper/backends/edx_auth_n_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/edx_auth_n_v1.py
@@ -1,7 +1,5 @@
 """ Backend abstraction. """
-from django.contrib.auth.backends import (  # pylint: disable=import-error
-    AllowAllUsersModelBackend,
-)
+from django.contrib.auth.backends import AllowAllUsersModelBackend  # pylint: disable=import-error
 from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError  # pylint: disable=import-error
 
 

--- a/eox_tenant/edxapp_wrapper/backends/edx_auth_n_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/edx_auth_n_v1.py
@@ -1,0 +1,15 @@
+""" Backend abstraction. """
+from django.contrib.auth.backends import (  # pylint: disable=import-error
+    AllowAllUsersModelBackend,
+)
+from openedx.core.djangoapps.user_authn.exceptions import AuthFailedError  # pylint: disable=import-error
+
+
+def get_edx_auth_backend():
+    """ Backend to get the default edx auth backend. """
+    return AllowAllUsersModelBackend
+
+
+def get_edx_auth_failed():
+    """ Backend to get the AuthFailedError class. """
+    return AuthFailedError

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -41,7 +41,7 @@ def plugin_settings(settings):
     settings.GET_CERTIFICATES_MODULE = 'eox_tenant.edxapp_wrapper.backends.certificates_module_i_v1'
     settings.GET_SITE_CONFIGURATION_MODULE = 'eox_tenant.edxapp_wrapper.backends.site_configuration_module_i_v1'
     settings.GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_h_v1'
-    settings.EOX_TENANT_EDX_AUTH_BACKEND = "eox_tenant.edxapp_wrapper.backends.edx_auth_i_v1"
+    settings.EOX_TENANT_EDX_AUTH_BACKEND = "eox_tenant.edxapp_wrapper.backends.edx_auth_n_v1"
     settings.EOX_TENANT_USERS_BACKEND = 'eox_tenant.edxapp_wrapper.backends.users_l_v1'
     settings.EOX_TENANT_BEARER_AUTHENTICATION = 'eox_tenant.edxapp_wrapper.backends.bearer_authentication_l_v1'
     settings.EOX_MAX_CONFIG_OVERRIDE_SECONDS = 300

--- a/eox_tenant/settings/production.py
+++ b/eox_tenant/settings/production.py
@@ -4,8 +4,7 @@ Settings for eox_tenant project meant to be called on the edx-platform/*/envs/pr
 
 from .common import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
-EDX_AUTH_BACKEND = \
-    'django.contrib.auth.backends.AllowAllUsersModelBackend'
+EDX_AUTH_BACKEND = 'django.contrib.auth.backends.AllowAllUsersModelBackend'
 EOX_TENANT_AUTH_BACKEND = 'eox_tenant.auth.TenantAwareAuthBackend'
 DJANGO_CURRENT_SITE_MIDDLEWARE = 'django.contrib.sites.middleware.CurrentSiteMiddleware'
 

--- a/eox_tenant/settings/production.py
+++ b/eox_tenant/settings/production.py
@@ -5,7 +5,7 @@ Settings for eox_tenant project meant to be called on the edx-platform/*/envs/pr
 from .common import *  # pylint: disable=wildcard-import,unused-wildcard-import
 
 EDX_AUTH_BACKEND = \
-    'openedx.core.djangoapps.oauth_dispatch.dot_overrides.backends.EdxRateLimitedAllowAllUsersModelBackend'
+    'django.contrib.auth.backends.AllowAllUsersModelBackend'
 EOX_TENANT_AUTH_BACKEND = 'eox_tenant.auth.TenantAwareAuthBackend'
 DJANGO_CURRENT_SITE_MIDDLEWARE = 'django.contrib.sites.middleware.CurrentSiteMiddleware'
 


### PR DESCRIPTION
**Summary:**

This PR fixes a bug in the `eox-tenant` functionality that restricted users from entering the LMS by their sign up source. The bug was introduced during the migration to Nuez, due to a change in the OpenEdX authentication backend.

**Details:**

- The migration to `Nuez` replaced `EdxRateLimitedAllowAllUsersModelBackend` with `AllowAllUsersModelBackend`, this change affected the `eox-tenant` functionality that restricted users by their sign-up source.

- For more information on the change in the authentication backend, see the Nutmeg release notes: [Nutmeg Release Notes](https://docs.openedx.org/en/latest/community/release_notes/nutmeg.html#removed-in-nutmeg).

**Steps to reproduce the issue:**

1. Have an environment with eox-tenant properly configured.
2. Create two tenants: A and B.
3. Configure both tenants with the following configuration in the tenant_config:
``` json

"FEATURES": {
  "EDNX_ENABLE_STRICT_LOGIN": true,
}

```
4. Register a user in tenant A and try to log in to tenant B.

**Solution:**

This PR modifies the eox-tenant code so that the user restriction functionality by sign up source works correctly with the new authentication backend.

Please let me know if you have any doubts or suggestions, thanks a lot for your help team :smile: 

