### PR TITLE
feat: allow user set language preference

### DIFF
--- a/eox_tenant/edxapp_wrapper/backends/lang_pref_middleware_p_test_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/lang_pref_middleware_p_test_v1.py
@@ -1,0 +1,8 @@
+"""
+LanguagePreferenceMiddleware Backend for testing.
+"""
+from unittest.mock import MagicMock
+
+def get_language_preference_middleware():
+    """Backend to mock the LanguagePreferenceMiddleware for testing."""
+    return MagicMock()

--- a/eox_tenant/edxapp_wrapper/backends/lang_pref_middleware_p_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/lang_pref_middleware_p_v1.py
@@ -1,0 +1,9 @@
+"""
+LanguagePreferenceMiddleware Backend.
+"""
+from openedx.core.djangoapps.lang_pref.middleware import LanguagePreferenceMiddleware  # pylint: disable=import-error
+
+
+def get_language_preference_middleware():
+    """Backend to get the LanguagePreferenceMiddleware from openedx."""
+    return LanguagePreferenceMiddleware

--- a/eox_tenant/edxapp_wrapper/language_preference.py
+++ b/eox_tenant/edxapp_wrapper/language_preference.py
@@ -1,0 +1,11 @@
+""" Backend abstraction. """
+from importlib import import_module
+
+from django.conf import settings
+
+
+def get_language_preference_middleware(*args, **kwargs):
+    """ Get DarkLangMiddleware. """
+    backend_function = settings.LANGUAGE_PREFERENCE_MIDDLEWARE
+    backend = import_module(backend_function)
+    return backend.get_language_preference_middleware(*args, **kwargs)

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -47,6 +47,7 @@ def plugin_settings(settings):
     settings.EOX_MAX_CONFIG_OVERRIDE_SECONDS = 300
     settings.EDXMAKO_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.edxmako_l_v1'
     settings.UTILS_MODULE_BACKEND = 'eox_tenant.edxapp_wrapper.backends.util_h_v1'
+    settings.LANGUAGE_PREFERENCE_MIDDLEWARE = 'eox_tenant.edxapp_wrapper.backends.lang_pref_middleware_p_v1'
     settings.CHANGE_DOMAIN_DEFAULT_SITE_NAME = "stage.edunext.co"
     settings.EOX_TENANT_LOAD_PERMISSIONS = True
     settings.EOX_TENANT_APPEND_LMS_MIDDLEWARE_CLASSES = False

--- a/eox_tenant/settings/test.py
+++ b/eox_tenant/settings/test.py
@@ -84,6 +84,8 @@ def plugin_settings(settings):  # pylint: disable=function-redefined
     settings.FEATURES['USE_REDIRECTION_MIDDLEWARE'] = False
     settings.GET_SITE_CONFIGURATION_MODULE = 'eox_tenant.edxapp_wrapper.backends.site_configuration_module_test_v1'
     settings.GET_THEMING_HELPERS = 'eox_tenant.edxapp_wrapper.backends.theming_helpers_test_v1'
+    settings.LANGUAGE_PREFERENCE_MIDDLEWARE = 'eox_tenant.edxapp_wrapper.backends.lang_pref_middleware_p_test_v1'
+
     settings.EOX_TENANT_SKIP_FILTER_FOR_TESTS = True
     settings.EOX_TENANT_LOAD_PERMISSIONS = False
     if hasattr(settings, 'OAUTH2_PROVIDER'):

--- a/eox_tenant/tenant_wise/__init__.py
+++ b/eox_tenant/tenant_wise/__init__.py
@@ -11,7 +11,7 @@ from django.conf import settings
 
 from eox_tenant.constants import LMS_ENVIRONMENT
 from eox_tenant.tenant_aware_functions.released_languages import tenant_languages
-from eox_tenant.tenant_wise.proxies import TenantSiteConfigProxy
+from eox_tenant.tenant_wise.proxies import LanguagePreferenceMiddlewareProxy, TenantSiteConfigProxy
 
 
 def load_tenant_wise_overrides():
@@ -38,6 +38,12 @@ def load_tenant_wise_overrides():
                     modules='openedx.core.djangoapps.lang_pref.api',
                     model='released_languages',
                     proxy=tenant_languages
+                )
+                
+                set_as_proxy(
+                    modules='openedx.core.djangoapps.lang_pref.middleware',
+                    model='LanguagePreferenceMiddleware',
+                    proxy=LanguagePreferenceMiddlewareProxy
                 )
 
 


### PR DESCRIPTION
This PR has the intention to allow users to change the website language preference based on their cockies. 

This PR is inspired by https://github.com/eduNEXT/eox-nelp/pull/127 and allows the normal behavior of the header and footer lang selectors for Django templates.