### PR TITLE
feat: create edx organization when updating course_org_filter `DS-961`

### DIFF
--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -13,7 +13,8 @@ DEBUG = True
 INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
-    'eox_tenant'
+    'eox_tenant',
+    'organizations',
 ]
 
 TIME_ZONE = 'UTC'

--- a/eox_tenant/utils.py
+++ b/eox_tenant/utils.py
@@ -5,6 +5,7 @@ import logging
 import re
 
 import six
+from organizations.models import Organization
 
 from eox_tenant.edxapp_wrapper.users import get_user_signup_source
 from eox_tenant.models import TenantOrganization
@@ -104,3 +105,4 @@ def synchronize_tenant_organizations(instance):
     for org in course_org_filter:
         organization, _ = TenantOrganization.objects.get_or_create(name=org)
         instance.organizations.add(organization)
+        Organization.objects.get_or_create(name=org, short_name=org)

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -11,3 +11,4 @@ edx-opaque-keys[django]
 openedx_filters
 social-auth-core
 edx-drf-extensions
+edx-organizations

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ charset-normalizer==3.3.2
     # via requests
 click==8.1.7
     # via edx-django-utils
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   pyjwt
     #   social-auth-core
@@ -30,7 +30,7 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 django==4.2.13
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-crum
@@ -54,7 +54,7 @@ django-mysql==4.13.0
     # via -r requirements/base.in
 django-simple-history==3.0.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   edx-organizations
 django-waffle==4.1.0
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,7 +10,7 @@ backports-zoneinfo==0.2.1
     # via
     #   django
     #   djangorestframework
-certifi==2024.2.2
+certifi==2024.6.2
     # via requests
 cffi==1.16.0
     # via
@@ -33,20 +33,27 @@ django==4.2.13
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-crum
+    #   django-model-utils
     #   django-mysql
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-organizations
     #   jsonfield
     #   openedx-filters
 django-crum==0.7.9
     # via
     #   -r requirements/base.in
     #   edx-django-utils
+django-model-utils==4.5.1
+    # via edx-organizations
 django-mysql==4.13.0
     # via -r requirements/base.in
+django-simple-history==3.7.0
+    # via edx-organizations
 django-waffle==4.1.0
     # via
     #   edx-django-utils
@@ -56,18 +63,24 @@ djangorestframework==3.15.1
     #   -r requirements/base.in
     #   drf-jwt
     #   edx-drf-extensions
+    #   edx-organizations
 dnspython==2.6.1
     # via pymongo
 drf-jwt==1.19.2
     # via edx-drf-extensions
-edx-django-utils==5.14.1
+edx-django-utils==5.14.2
     # via edx-drf-extensions
 edx-drf-extensions==10.3.0
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   edx-organizations
 edx-opaque-keys[django]==2.9.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
+    #   edx-organizations
+edx-organizations==6.13.0
+    # via -r requirements/base.in
 idna==3.7
     # via requests
 jsonfield==3.1.0
@@ -82,6 +95,8 @@ openedx-filters==1.8.1
     # via -r requirements/base.in
 pbr==6.0.0
     # via stevedore
+pillow==10.3.0
+    # via edx-organizations
 psutil==5.9.8
     # via edx-django-utils
 pycparser==2.22
@@ -116,9 +131,12 @@ stevedore==5.2.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.12.0
+typing-extensions==4.12.1
     # via
     #   asgiref
     #   edx-opaque-keys
 urllib3==2.2.1
     # via requests
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,12 +30,12 @@ defusedxml==0.8.0rc2
     #   social-auth-core
 django==4.2.13
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
     #   django-crum
     #   django-model-utils
     #   django-mysql
-    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
@@ -52,8 +52,10 @@ django-model-utils==4.5.1
     # via edx-organizations
 django-mysql==4.13.0
     # via -r requirements/base.in
-django-simple-history==3.7.0
-    # via edx-organizations
+django-simple-history==3.0.0
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   edx-organizations
 django-waffle==4.1.0
     # via
     #   edx-django-utils

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,5 +10,5 @@
 
 Django<5
 
-# Common constraints for edx repos
--c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+# Common constraints for Open edX repos
+-c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -9,3 +9,6 @@
 # linking to it here is good.
 
 Django<5
+
+# Common constraints for edx repos
+-c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -10,7 +10,7 @@ click==8.1.7
     # via pip-tools
 importlib-metadata==6.11.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   build
 packaging==24.0
     # via build

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -24,7 +24,7 @@ tomli==2.0.1
     #   pip-tools
 wheel==0.43.0
     # via pip-tools
-zipp==3.19.0
+zipp==3.19.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,8 +8,10 @@ build==1.2.1
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==7.1.0
-    # via build
+importlib-metadata==6.11.0
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   build
 packaging==24.0
     # via build
 pip-tools==7.4.1

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -34,7 +34,7 @@ click==8.1.7
     #   edx-django-utils
 coverage==7.5.3
     # via -r requirements/test.in
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -49,7 +49,7 @@ defusedxml==0.8.0rc2
 dill==0.3.8
     # via pylint
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-crum
@@ -77,7 +77,7 @@ django-mysql==4.13.0
     # via -r requirements/base.txt
 django-simple-history==3.0.0
     # via
-    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -c https://raw.githubusercontent.com/openedx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-organizations
 django-waffle==4.1.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -15,7 +15,7 @@ backports-zoneinfo==0.2.1
     #   -r requirements/base.txt
     #   django
     #   djangorestframework
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -r requirements/base.txt
     #   requests
@@ -52,12 +52,15 @@ dill==0.3.8
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-crum
+    #   django-model-utils
     #   django-mysql
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
     #   edx-django-utils
     #   edx-drf-extensions
+    #   edx-organizations
     #   jsonfield
     #   openedx-filters
 django-crum==0.7.9
@@ -66,8 +69,16 @@ django-crum==0.7.9
     #   edx-django-utils
 django-fake-model==0.1.4
     # via -r requirements/test.in
+django-model-utils==4.5.1
+    # via
+    #   -r requirements/base.txt
+    #   edx-organizations
 django-mysql==4.13.0
     # via -r requirements/base.txt
+django-simple-history==3.7.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-organizations
 django-waffle==4.1.0
     # via
     #   -r requirements/base.txt
@@ -78,6 +89,7 @@ djangorestframework==3.15.1
     #   -r requirements/base.txt
     #   drf-jwt
     #   edx-drf-extensions
+    #   edx-organizations
 dnspython==2.6.1
     # via
     #   -r requirements/base.txt
@@ -86,16 +98,21 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-edx-django-utils==5.14.1
+edx-django-utils==5.14.2
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
 edx-drf-extensions==10.3.0
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   edx-organizations
 edx-opaque-keys[django]==2.9.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
+    #   edx-organizations
+edx-organizations==6.13.0
+    # via -r requirements/base.txt
 idna==3.7
     # via
     #   -r requirements/base.txt
@@ -127,6 +144,10 @@ pbr==6.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
+pillow==10.3.0
+    # via
+    #   -r requirements/base.txt
+    #   edx-organizations
 platformdirs==4.2.2
     # via pylint
 psutil==5.9.8
@@ -194,7 +215,7 @@ tomli==2.0.1
     # via pylint
 tomlkit==0.12.5
     # via pylint
-typing-extensions==4.12.0
+typing-extensions==4.12.1
     # via
     #   -r requirements/base.txt
     #   asgiref
@@ -205,3 +226,6 @@ urllib3==2.2.1
     # via
     #   -r requirements/base.txt
     #   requests
+
+# The following packages are considered to be unsafe in a requirements file:
+# setuptools

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -49,12 +49,12 @@ defusedxml==0.8.0rc2
 dill==0.3.8
     # via pylint
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   django-crum
     #   django-model-utils
     #   django-mysql
-    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
@@ -75,8 +75,9 @@ django-model-utils==4.5.1
     #   edx-organizations
 django-mysql==4.13.0
     # via -r requirements/base.txt
-django-simple-history==3.7.0
+django-simple-history==3.0.0
     # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
     #   -r requirements/base.txt
     #   edx-organizations
 django-waffle==4.1.0


### PR DESCRIPTION
## Description

This PR adds the creation (if it does not exist) of an edX organization each time the `course_org_filter` property is updated in the **LMS Configs** of each **Tenant Config**.

## Testing instructions

1. Install the plugin with these changes (If you are installing it for the first time you should run the migrations).
2. Create a new **Tenant Config** from `{lms-domain}/admin/eox_tenant/tenantconfig/`
3. In the **lms config** field add the **course_org_filter** property and save:

    ```json
    {
       "course_org_filter": [
          "edunext",
          "edX",
          ...
       ]
    }
    ```
4. Go to `{lms-domain}/admin/organizations/organization/`, you should see the new organizations.

## Additional information

https://github.com/eduNEXT/eox-tenant/issues/165

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits