### PR TITLE
docs: improve the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,49 @@
-
+==========
 EOX tenant
-----------
-Eox-tenant is a multi-tenancy django app for `edx-platform`_. It is build as an `openedx plugin`_ so even as a django app it will auto install in the larger edx-platform core code once installed in the same python environment.
+==========
+|Maintainance Badge| |Test Badge| |PyPI Badge|
 
-The code is written and maintained by `eduNEXT`_ and it is what we use to support our own multi-tenant services. It was initially created as an extension of the `microsites` and `site_configurations` features of the Open edX platform, but it has grown to completely replace them in order to support more robust multi tenancy model.
+.. |Maintainance Badge| image:: https://img.shields.io/badge/Status-Maintained-brightgreen
+   :alt: Maintainance Status
+.. |Test Badge| image:: https://img.shields.io/github/actions/workflow/status/edunext/eox-tenant/.github%2Fworkflows%2Ftests.yml?label=Test
+   :alt: GitHub Actions Workflow Test Status
+.. |PyPI Badge| image:: https://img.shields.io/pypi/v/eox-tenant?label=PyPI
+   :alt: PyPI - Version
+   
+Eox-tenant is a multi-tenancy Django app for `edx-platform`_. It is built as an `openedx plugin`_ so even as a Django app it will autoinstall in the larger edx-platform core code once installed in the same Python environment.
 
-If you are looking for professional development or support with multi tenancy or multi sites in the Open edX platform, you can reach out at sales@edunext.co
+The code is written and maintained by `edunex`_ and we use it to support our multi-tenant services. It was initially created as an extension of the `microsites` and `site_configurations` features of the Open edX platform, however, it has grown to completely replace them to support a more robust multitenancy model.
+
+If you are looking for professional development or support with multitenancy or multi-sites in the Open edX platform, you can reach out to sales@edunext.co
 
 .. _openedx plugin: https://github.com/edx/edx-platform/tree/master/openedx/core/djangoapps/plugins
 .. _edx-platform: https://github.com/edx/edx-platform/
 .. _eduNEXT: https://www.edunext.co
 
+Installation
+============
+
+#. Add this plugin in your Tutor ``config.yml`` with the ``OPENEDX_EXTRA_PIP_REQUIREMENTS`` setting.
+
+   .. code-block:: yaml
+      
+      OPENEDX_EXTRA_PIP_REQUIREMENTS:
+         - eox-tenant=={{version}}
+         
+#. Save the configuration with ``tutor config save``.
+#. Build an open edx image with ``tutor images build openedx``.
+#. Launch your platform with ``tutor local launch``.
+
+Usage
+=====
+Onece your instance is running you can access the Django admin site and locate the ``EDUNEXT OPENEDX MULTITENANCY`` models.
+
+- Microsites
+- Routes
+- Tenant configs
+- Tenant organizations
+
+ 
 Compatibility Notes
 --------------------
 
@@ -38,7 +71,7 @@ Compatibility Notes
 | Redwood          | >= v11.7.0            |
 +------------------+-----------------------+
 
-**NOTE**: Since 6.2 version, eox-tenant does not support Django 2.2
+**NOTE**: Since the 6.2 version, eox-tenant does not support Django 2.2
 
 The following changes to the plugin settings are necessary. If the release you are looking for is
 not listed, then the accumulation of changes from previous releases is enough.
@@ -132,10 +165,9 @@ From version **1.0.0**\ , middlewares **RedirectionsMiddleware** and **PathRedir
    The table corresponding to the Redirection model will not be deleted but it will be discarded from the Django state
 
 Commands
-########
-
+--------
 Synchronize Organizations
-*************************
+^^^^^^^^^^^^^^^^^^^^^^^^^
 This command will synchronize the course_org_filter values in lms_configs(TenantConfig model) or values(Microsite model) with the TenantOrganization registers, if the organization does not exist, it will be created, otherwise it will be add to the organizations model field.
 
 
@@ -146,15 +178,15 @@ This command will synchronize the course_org_filter values in lms_configs(Tenant
   ./manage.py lms synchronize_organizations --model Microsite # only for Microsite
 
 Create/Edit tenant configuration
-********************************
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 `create_or_update_tenant_config` helps to add or edit ``TenantConfig`` and linked ``Routes`` via command line.
 
 .. code-block:: bash
 
-  # this command will create/edit entry in TenantConfig with external_key lacolhost.com and update its JSONField(s) with passed json content.
+  # This command will create/edit an entry in TenantConfig with external_key lacolhost.com and update its JSONField(s) with passed JSON content.
   ./manage.py lms create_or_update_tenant_config --external-key lacolhost.com --config '{"lms_configs": {"PLATFORM_NAME": "Lacolhost"}, "studio_configs": {"PLATFORM_NAME": "Lacolhost"}}' lacolhost.com studio.lacolhost.com preview.lacolhost.com
 
-  # this command will create/edit entry in TenantConfig with external_key lacolhost.com and update its JSONField(s) with passed json config file content.
+  # This command will create/edit an entry in TenantConfig with external_key lacolhost.com and update its JSONField(s) with passed JSON config file content.
   ./manage.py lms create_or_update_tenant_config --external-key lacolhost.com --config-file /tmp/some.json lacolhost.com studio.lacolhost.com preview.lacolhost.com
 
   # Same as above, but it will override configuration instead of updating it.
@@ -163,14 +195,14 @@ Create/Edit tenant configuration
 Caveats
 -------
 
-- SSO that uses the LMS while authenticating does so with server-to-server communication. Therefore, when the `AvailableScreenMiddleware` gets the current domain, it finds that `lms:8000` as in `SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT` which does not exist, then raises 404 exception. In order to avoid this error, set in your LMS settings file:
+- SSO that uses the LMS while authenticating does so with server-to-server communication. Therefore, when the `AvailableScreenMiddleware` gets the current domain, it finds that `lms:8000` as in `SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT` which does not exist, then raises a 404 exception. To avoid this error, set in your LMS settings file:
 
 .. code-block:: python
 
   SOCIAL_AUTH_EDX_OAUTH2_URL_ROOT = SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT
 
 How to Contribute
------------------
+=================
 
 Contributions are welcome! See our `CONTRIBUTING`_ file for more
 information – it also contains guidelines for how to maintain high code

--- a/README.rst
+++ b/README.rst
@@ -10,15 +10,11 @@ EOX Tenant
 .. |PyPI Badge| image:: https://img.shields.io/pypi/v/eox-tenant?label=PyPI
    :alt: PyPI - Version
    
-Eox-tenant is a multi-tenancy Django app for `edx-platform`_. It is built as an `openedx plugin`_ so even as a Django app it will be auto-installed in the larger edx-platform core code once is installed in the same Python environment.
-
-The code is written and maintained by `edunext`_ and we use it to support our multi-tenant services. It was initially created as an extension of the `microsites` and `site_configurations` features of the Open edX platform, however, it has grown to completely replace them to support a more robust multitenancy model.
+Eox-tenant is a plugin for `Open edX`_, and part of the Edunext Open Extensions (aka EOX), that replaces the microsites and site_configurations features, offering a more robust multi-tenancy model.
 
 If you are looking for professional development or support with multitenancy or multi-sites in the Open edX platform, you can reach out to sales@edunext.co
 
-.. _openedx plugin: https://github.com/openedx/edx-platform/tree/master/openedx/core/djangoapps/plugins
-.. _edx-platform: https://github.com/openedx/edx-platform/
-.. _eduNEXT: https://www.edunext.co
+.. _Open edX: https://github.com/openedx/edx-platform/
 
 Installation
 ============
@@ -31,8 +27,7 @@ Installation
          - eox-tenant=={{version}}
          
 #. Save the configuration with ``tutor config save``.
-#. Build an open edx image with ``tutor images build openedx``.
-#. Launch your platform with ``tutor local launch``.
+#. Build the image and launch your platform with ``tutor local launch``.
 
 Usage
 =====
@@ -45,7 +40,7 @@ Once your instance is running, you can access the Django admin site and locate t
 - **Tenant organizations:** Link each organization with one or multiple tenants.
 
 Add ``EDNX_USE_SIGNAL = True`` in each microsite/tenant that wants to use the plugin. 
- 
+
 Compatibility Notes
 --------------------
 
@@ -73,7 +68,7 @@ Compatibility Notes
 | Redwood          | >= v11.7.0            |
 +------------------+-----------------------+
 
-**NOTE**: Since the 6.2 version, eox-tenant does not support Django 2.2
+⚠️ Since the 6.2 version, eox-tenant does not support Django 2.2
 
 The plugin is configured for the latest release (Quince). The following changes in the plugin settings should be applied to be used for previous releases.
 
@@ -89,18 +84,20 @@ For version  11.X compatible
 
 Those settings can be changed in ``eox_tenant/settings/common.py`` or, for example, in the instance settings.
 
-**NOTE**
+If you are installing a previous version, please refer to the tag to verify the configuration that should be applied.
 
-For version > 10.0.0 you need to enable eox-tenant adding in the LMS configuration:
- 
+🚨 For version > 10.0.0 you need to enable eox-tenant adding in the LMS configuration:
+
 .. code-block:: yaml
   
   USE_EOX_TENANT = True
 
 Commands
 --------
+
 Synchronize Organizations
 ^^^^^^^^^^^^^^^^^^^^^^^^^
+
 This command will synchronize the course_org_filter values in lms_configs(TenantConfig model) or values(Microsite model) with the TenantOrganization registers if the organization does not exist, it will be created, otherwise, it will be added to the organizations model field.
 
 
@@ -112,6 +109,7 @@ This command will synchronize the course_org_filter values in lms_configs(Tenant
 
 Create/Edit tenant configuration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 `create_or_update_tenant_config` helps to add or edit ``TenantConfig`` and linked ``Routes`` via command line.
 
 .. code-block:: bash
@@ -131,7 +129,7 @@ Migration notes
 
 **Migrating from 0.* version to 1.0.0**
 
-From version **1.0.0**, middlewares **RedirectionsMiddleware** and **PathRedirectionMiddleware** are no longer supported in this plugin. These middlewares were moved to the **eox-core** plugin `here <https://github.com/eduNEXT/eox-core/>`_. From this, you can have three cases:
+From version **1.0.0**, **RedirectionsMiddleware** and **PathRedirectionMiddleware** are no longer supported in this plugin. These middleware were moved to the **eox-core** plugin `here <https://github.com/eduNEXT/eox-core/>`_. From this, you can have three cases:
 
 
 #. You have already installed eox-core alongside eox-tenant. In this case, you need to:
@@ -145,7 +143,7 @@ From version **1.0.0**, middlewares **RedirectionsMiddleware** and **PathRedirec
      ./manage.py lms migrate eox_core --fake-initial --settings=<your app settings>
 
 
-#. You only have installed eox-tenant and you want to keep the functionality that middlewares offer. You need to:
+#. You only have installed eox-tenant and you want to keep the functionality that middleware offer. You need to:
 
    * Install eox-core version **2.0.0** as edx-platform requirement. You can use *Ansible* to add this plugin as an extra requirement.
 
@@ -157,14 +155,13 @@ From version **1.0.0**, middlewares **RedirectionsMiddleware** and **PathRedirec
      ./manage.py manage.py lms migrate eox_core --fake-initial --settings=<your app settings>
 
 
-#. In the case you are not using the redirection middlewares, and only have eox-tenant installed, you can simply apply the database migrations for the eox-tenant plugin:
+#. In the case you are not using the redirection middleware, and only have eox-tenant installed, you can simply apply the database migrations for the eox-tenant plugin:
 
    .. code-block:: bash
 
      ./manage.py manage.py lms migrate eox_tenant --settings=<your app settings>
 
    The table corresponding to the Redirection model will not be deleted but it will be discarded from the Django state
-
 
 Caveats
 -------

--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ The code is written and maintained by `edunext`_ and we use it to support our mu
 
 If you are looking for professional development or support with multitenancy or multi-sites in the Open edX platform, you can reach out to sales@edunext.co
 
-.. _openedx plugin: https://github.com/edx/edx-platform/tree/master/openedx/core/djangoapps/plugins
-.. _edx-platform: https://github.com/edx/edx-platform/
+.. _openedx plugin: https://github.com/openedx/edx-platform/tree/master/openedx/core/djangoapps/plugins
+.. _edx-platform: https://github.com/openedx/edx-platform/
 .. _eduNEXT: https://www.edunext.co
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,9 @@ EOX tenant
 .. |PyPI Badge| image:: https://img.shields.io/pypi/v/eox-tenant?label=PyPI
    :alt: PyPI - Version
    
-Eox-tenant is a multi-tenancy Django app for `edx-platform`_. It is built as an `openedx plugin`_ so even as a Django app it will autoinstall in the larger edx-platform core code once installed in the same Python environment.
+Eox-tenant is a multi-tenancy Django app for `edx-platform`_. It is built as an `openedx plugin`_ so even as a Django app it will be auto-installed in the larger edx-platform core code once is installed in the same Python environment.
 
-The code is written and maintained by `edunex`_ and we use it to support our multi-tenant services. It was initially created as an extension of the `microsites` and `site_configurations` features of the Open edX platform, however, it has grown to completely replace them to support a more robust multitenancy model.
+The code is written and maintained by `edunext`_ and we use it to support our multi-tenant services. It was initially created as an extension of the `microsites` and `site_configurations` features of the Open edX platform, however, it has grown to completely replace them to support a more robust multitenancy model.
 
 If you are looking for professional development or support with multitenancy or multi-sites in the Open edX platform, you can reach out to sales@edunext.co
 
@@ -36,13 +36,15 @@ Installation
 
 Usage
 =====
-Onece your instance is running you can access the Django admin site and locate the ``EDUNEXT OPENEDX MULTITENANCY`` models.
 
-- Microsites
-- Routes
-- Tenant configs
-- Tenant organizations
+Once your instance is running, you can access the Django admin site and locate the ``EDUNEXT OPENEDX MULTITENANCY`` models.
 
+- **Microsites:** Store the microsite configuration.
+- **Routes:** Configure the URL for a tenant.
+- **Tenant configs:** Store the configuration for each tenant.
+- **Tenant organizations:** Link each organization with one or multiple tenants.
+
+Add ``EDNX_USE_SIGNAL = True`` in each microsite/tenant that wants to use the plugin. 
  
 Compatibility Notes
 --------------------
@@ -73,102 +75,33 @@ Compatibility Notes
 
 **NOTE**: Since the 6.2 version, eox-tenant does not support Django 2.2
 
-The following changes to the plugin settings are necessary. If the release you are looking for is
-not listed, then the accumulation of changes from previous releases is enough.
+The plugin is configured for the latest release (Quince). The following changes in the plugin settings should be applied to be used for previous releases.
 
-**Ironwood**
-
-.. code-block:: yaml
-
-  GET_BRANDING_API: 'eox_tenant.edxapp_wrapper.backends.branding_api_h_v1'
-  GET_CERTIFICATES_MODULE: 'eox_tenant.edxapp_wrapper.backends.certificates_module_i_v1'
-  GET_SITE_CONFIGURATION_MODULE: 'eox_tenant.edxapp_wrapper.backends.site_configuration_module_i_v1'
-  GET_THEMING_HELPERS: 'eox_tenant.edxapp_wrapper.backends.theming_helpers_h_v1'
-  EOX_TENANT_EDX_AUTH_BACKEND: "eox_tenant.edxapp_wrapper.backends.edx_auth_i_v1"
-  EOX_TENANT_USERS_BACKEND: 'eox_tenant.edxapp_wrapper.backends.users_i_v1'
-  EDXMAKO_MODULE_BACKEND: 'eox_tenant.edxapp_wrapper.backends.edxmako_h_v1'
-  UTILS_MODULE_BACKEND: 'eox_tenant.edxapp_wrapper.backends.util_h_v1'
-
-**Juniper**
-
-For version >= 3.4
-
-.. code-block:: yaml
-
-  GET_OAUTH_DISPATCH_BACKEND: 'eox_tenant.edxapp_wrapper.backends.oauth_dispatch_j_v1'
-
-**Koa (optional)**
-
-.. code-block:: yaml
-
-  GET_BRANDING_API: 'eox_tenant.edxapp_wrapper.backends.branding_api_l_v1'
-  EOX_TENANT_USERS_BACKEND: 'eox_tenant.edxapp_wrapper.backends.users_l_v1'
-  EDXMAKO_MODULE_BACKEND: eox_tenant.edxapp_wrapper.backends.edxmako_l_v1
-
-**Lilac**
-
-.. code-block:: yaml
-
-  GET_BRANDING_API: 'eox_tenant.edxapp_wrapper.backends.branding_api_l_v1'
-  EOX_TENANT_USERS_BACKEND: 'eox_tenant.edxapp_wrapper.backends.users_l_v1'
-  EDXMAKO_MODULE_BACKEND: eox_tenant.edxapp_wrapper.backends.edxmako_l_v1
+If the release you are looking for is not listed, the actual configuration is sufficient or it is incompatible with the current eox-tenant version.
 
 **Maple**
 
+For version  11.X compatible
+
 .. code-block:: yaml
 
-  GET_BRANDING_API: 'eox_tenant.edxapp_wrapper.backends.branding_api_l_v1'
-  EOX_TENANT_USERS_BACKEND: 'eox_tenant.edxapp_wrapper.backends.users_l_v1'
-  EDXMAKO_MODULE_BACKEND: eox_tenant.edxapp_wrapper.backends.edxmako_l_v1
+  EOX_TENANT_EDX_AUTH_BACKEND = "eox_tenant.edxapp_wrapper.backends.edx_auth_i_v1"
 
 Those settings can be changed in ``eox_tenant/settings/common.py`` or, for example, in ansible configurations.
 
-**NOTE**: the current ``common.py`` works with Open edX Redwood version.
+**NOTE**
 
-Migration notes
----------------
-
-**Migrating from 0.* version to 1.0.0**
-
-From version **1.0.0**\ , middlewares **RedirectionsMiddleware** and **PathRedirectionMiddleware** are not longer supported in this plugin.These middlewares were moved to the **eox-core** plugin `here <https://github.com/eduNEXT/eox-core/>`_. From this, you can have three cases:
-
-
-#. You have already installed eox-core alongside eox-tenant. In this case you need to:
-
-   * Upgrade eox-core to version **2.0.0** (previous releases are not compatible with eox-tenant 1.0.0)
-   * Run the plugin migrations as indicated below:
-
-   .. code-block:: bash
-
-     ./manage.py lms migrate eox_tenant --settings=<your app settings>
-     ./manage.py lms migrate eox_core --fake-initial --settings=<your app settings>
-
-
-#. You only have installed eox-tenant and you want to keep the functionality that middlewares offer. You need to:
-
-   * Install eox-core version **2.0.0** as edx-platform requirement. You can use *Ansible* to add this plugin as an extra requirement.
-
-   * Run the plugin migrations as indicated below:
-
-   .. code-block:: bash
-
-     ./manage.py lms migrate eox_tenant --settings=<your app settings>
-     ./manage.py manage.py lms migrate eox_core --fake-initial --settings=<your app settings>
-
-
-#. In the case your are not using the redirection middlewares, and only have eox-tenant installed, you can simply apply the database migrations for the eox-tenant plugin:
-
-   .. code-block:: bash
-
-     ./manage.py manage.py lms migrate eox_tenant --settings=<your app settings>
-
-   The table corresponding to the Redirection model will not be deleted but it will be discarded from the Django state
+For version > 10.0.0 you need to enable eox-tenant adding in the LMS configuration:
+ 
+.. code-block:: yaml
+  
+  USE_EOX_TENANT = True
 
 Commands
 --------
 Synchronize Organizations
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-This command will synchronize the course_org_filter values in lms_configs(TenantConfig model) or values(Microsite model) with the TenantOrganization registers, if the organization does not exist, it will be created, otherwise it will be add to the organizations model field.
+This command will synchronize the course_org_filter values in lms_configs(TenantConfig model) or values(Microsite model) with the TenantOrganization registers if the organization does not exist, it will be created, otherwise, it will be added to the organizations model field.
 
 
 .. code-block:: bash
@@ -192,6 +125,47 @@ Create/Edit tenant configuration
   # Same as above, but it will override configuration instead of updating it.
   ./manage.py lms create_or_update_tenant_config --external-key lacolhost.com --config-file /tmp/some.json lacolhost.com studio.lacolhost.com preview.lacolhost.com --override
 
+
+Migration notes
+===============
+
+**Migrating from 0.* version to 1.0.0**
+
+From version **1.0.0**, middlewares **RedirectionsMiddleware** and **PathRedirectionMiddleware** are no longer supported in this plugin. These middlewares were moved to the **eox-core** plugin `here <https://github.com/eduNEXT/eox-core/>`_. From this, you can have three cases:
+
+
+#. You have already installed eox-core alongside eox-tenant. In this case, you need to:
+
+   * Upgrade eox-core to version **2.0.0** (previous releases are not compatible with eox-tenant 1.0.0)
+   * Run the plugin migrations as indicated below:
+
+   .. code-block:: bash
+
+     ./manage.py lms migrate eox_tenant --settings=<your app settings>
+     ./manage.py lms migrate eox_core --fake-initial --settings=<your app settings>
+
+
+#. You only have installed eox-tenant and you want to keep the functionality that middlewares offer. You need to:
+
+   * Install eox-core version **2.0.0** as edx-platform requirement. You can use *Ansible* to add this plugin as an extra requirement.
+
+   * Run the plugin migrations as indicated below:
+
+   .. code-block:: bash
+
+     ./manage.py lms migrate eox_tenant --settings=<your app settings>
+     ./manage.py manage.py lms migrate eox_core --fake-initial --settings=<your app settings>
+
+
+#. In the case you are not using the redirection middlewares, and only have eox-tenant installed, you can simply apply the database migrations for the eox-tenant plugin:
+
+   .. code-block:: bash
+
+     ./manage.py manage.py lms migrate eox_tenant --settings=<your app settings>
+
+   The table corresponding to the Redirection model will not be deleted but it will be discarded from the Django state
+
+
 Caveats
 -------
 
@@ -209,3 +183,8 @@ information – it also contains guidelines for how to maintain high code
 quality, which will make your contribution more likely to be accepted.
 
 .. _CONTRIBUTING: https://github.com/eduNEXT/eox-tenant/blob/master/CONTRIBUTING.rst
+
+License
+=======
+
+This project is licensed under the AGPL-3.0 License. See the LICENSE file for details.

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ EOX Tenant
 .. |PyPI Badge| image:: https://img.shields.io/pypi/v/eox-tenant?label=PyPI
    :alt: PyPI - Version
    
-Eox-tenant is a plugin for `Open edX`_, and part of the Edunext Open Extensions (aka EOX), that replaces the microsites and site_configurations features, offering a more robust multi-tenancy model.
+Eox-tenant is a plugin for `Open edX`_, and part of the Edunext Open edX Extensions (aka EOX), that replaces the microsites and site_configurations features, offering a more robust multi-tenancy model.
 
 If you are looking for professional development or support with multitenancy or multi-sites in the Open edX platform, you can reach out to sales@edunext.co
 
@@ -44,35 +44,33 @@ Add ``EDNX_USE_SIGNAL = True`` in each microsite/tenant that wants to use the pl
 Compatibility Notes
 --------------------
 
-+------------------+-----------------------+
-| Open edX Release | Version               |
-+==================+=======================+
-| Ironwood         | < 3.0                 |
-+------------------+-----------------------+
-| Juniper          | >= 3.0 < 4.0          |
-+------------------+-----------------------+
-| Koa              | >= 4.0 <= 5.1.3       |
-+------------------+-----------------------+
-| Lilac            | >= 4.0 < 6.2          |
-+------------------+-----------------------+
-| Maple            | >= 6.0                |
-+------------------+-----------------------+
-| Nutmeg           | >= 6.2                |
-+------------------+-----------------------+
-| Olive            | >= 8.0                |
-+------------------+-----------------------+
-| Palm             | >= v11.7.0            |
-+------------------+-----------------------+
-| Quince           | >= v11.7.0            |
-+------------------+-----------------------+
-| Redwood          | >= v11.7.0            |
-+------------------+-----------------------+
++------------------+-----------------+
+| Open edX Release | Version         |
++==================+=================+
+| Ironwood         | < 3.0           |
++------------------+-----------------+
+| Juniper          | >= 3.0 < 4.0    |
++------------------+-----------------+
+| Koa              | >= 4.0 <= 5.1.3 |
++------------------+-----------------+
+| Lilac            | >= 4.0 < 6.2    |
++------------------+-----------------+
+| Maple            | >= 6.0          |
++------------------+-----------------+
+| Nutmeg           | >= 6.2          |
++------------------+-----------------+
+| Olive            | >= 8.0          |
++------------------+-----------------+
+| Palm             | >= v11.7.0      |
++------------------+-----------------+
+| Quince           | >= v11.7.0      |
++------------------+-----------------+
+| Redwood          | >= v11.7.0      |
++------------------+-----------------+
 
 ⚠️ Since the 6.2 version, eox-tenant does not support Django 2.2
 
-The plugin is configured for the latest release (Quince). The following changes in the plugin settings should be applied to be used for previous releases.
-
-If the release you are looking for is not listed, the actual configuration is sufficient or it is incompatible with the current eox-tenant version.
+The plugin is configured for the latest release (Redwood). The following changes in the plugin settings should be applied to be used for previous releases.
 
 **Maple**
 
@@ -84,7 +82,10 @@ For version  11.X compatible
 
 Those settings can be changed in ``eox_tenant/settings/common.py`` or, for example, in the instance settings.
 
-If you are installing a previous version, please refer to the tag to verify the configuration that should be applied.
+🚨 If the release you are looking for is not listed, please note:
+
+- If the Open edX release is compatible with the current eox-tenant version (see `Compatibility Notes <https://github.com/eduNEXT/eox-tenant?tab=readme-ov-file#compatibility-notes>`_), the default configuration is sufficient.
+- If incompatible, you can refer to the README from the relevant version tag for configuration details (e.g., `v6.2.0 README <https://github.com/eduNEXT/eox-tenant/blob/v6.2.0/README.rst>`_).
 
 🚨 For version > 10.0.0 you need to enable eox-tenant adding in the LMS configuration:
 

--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ Those settings can be changed in ``eox_tenant/settings/common.py`` or, for examp
 - If the Open edX release is compatible with the current eox-tenant version (see `Compatibility Notes <https://github.com/eduNEXT/eox-tenant?tab=readme-ov-file#compatibility-notes>`_), the default configuration is sufficient.
 - If incompatible, you can refer to the README from the relevant version tag for configuration details (e.g., `v6.2.0 README <https://github.com/eduNEXT/eox-tenant/blob/v6.2.0/README.rst>`_).
 
-🚨 For version > 10.0.0 you need to enable eox-tenant adding in the LMS configuration:
+🚨 For version < 10.0.0 you need to enable eox-tenant adding in the LMS configuration:
 
 .. code-block:: yaml
   

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 ==========
-EOX tenant
+EOX Tenant
 ==========
 |Maintainance Badge| |Test Badge| |PyPI Badge|
 
@@ -87,7 +87,7 @@ For version  11.X compatible
 
   EOX_TENANT_EDX_AUTH_BACKEND = "eox_tenant.edxapp_wrapper.backends.edx_auth_i_v1"
 
-Those settings can be changed in ``eox_tenant/settings/common.py`` or, for example, in ansible configurations.
+Those settings can be changed in ``eox_tenant/settings/common.py`` or, for example, in the instance settings.
 
 **NOTE**
 

--- a/README.rst
+++ b/README.rst
@@ -187,4 +187,4 @@ quality, which will make your contribution more likely to be accepted.
 License
 =======
 
-This project is licensed under the AGPL-3.0 License. See the LICENSE file for details.
+This project is licensed under the AGPL-3.0 License. See the `LICENSE <LICENSE.txt>`_ file for details.

--- a/eox_tenant/edxapp_wrapper/backends/branding_api_l_v1.py
+++ b/eox_tenant/edxapp_wrapper/backends/branding_api_l_v1.py
@@ -7,7 +7,7 @@ except ImportError:
 
 def get_branding_api():
     """Allow to get the branding api module
-    https://github.com/edx/edx-platform/blob/open-release/lilac.master/lms/djangoapps/branding/api.py
+    https://github.com/openedx/edx-platform/blob/open-release/lilac.master/lms/djangoapps/branding/api.py
 
     Returns:
         branding_api module.

--- a/eox_tenant/settings/common.py
+++ b/eox_tenant/settings/common.py
@@ -32,7 +32,7 @@ DATABASES = {
 def plugin_settings(settings):
     """
     Set of plugin settings used by the Open Edx platform.
-    More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
+    More info: https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
     # Plugin settings.
     settings.CONTENTSTORE_PATH = 'cms.djangoapps.contentstore.utils'

--- a/eox_tenant/settings/production.py
+++ b/eox_tenant/settings/production.py
@@ -18,7 +18,7 @@ EOX_TENANT_MIDDLEWARES = [
 def plugin_settings(settings):  # pylint: disable=function-redefined
     """
     Set of plugin settings used by the Open Edx platform.
-    More info: https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
+    More info: https://github.com/openedx/edx-platform/blob/master/openedx/core/djangoapps/plugins/README.rst
     """
     # Backend settings.
     settings.CONTENTSTORE_PATH = getattr(settings, 'ENV_TOKENS', {}).get(


### PR DESCRIPTION
This PR improves the repository documentation for a better understanding of the eox-tenant plugin.


For the plugin description

>  Plugin for managing multiple tenants (organizations) within a single Open edX instance, replacing the microsites and site configuration features with a more robust multi-tenancy model.


**Proposal** 

➡️ Maintain the settings configuration for the current release. 

- **Simplification**: Find the necessary information without being distracted by details that may no longer be relevant (e.g. Ironwood).
- **Relevance**: Users typically work with recent versions of software. Documenting the latest settings ensures that our documentation is pertinent and useful for most users.
- **Maintenance**:  We lower the risk of outdated information and reduce the effort required to keep the documentation current. (e.g., before Redwood we have that the current configuration works for Juniper, that is not true because the latest version at that moment doesn't support that release). 
- **Accuracy**: During the migration process, we are adding the name of the previous release in the documentation even when the settings are the same, which could lead to unnecessary action for the user.

Also, the packages management like (pypi or npm - use the readme and the latest release to explain the documentation)  if you want to install another version you should select it and that will show you the relevant information for that tag (readme for that version). That behavior is another motivation for this change, showing the information relevant to the version that the user wants to use. 


**Additional information**
[JIRA](https://edunext.atlassian.net/browse/DS-971)