### PR TITLE
temp: disable automatic bump-version

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,4 +1,4 @@
-name: Bump version
+name: Bump version - Disabled
 on:
   push:
     branches:


### PR DESCRIPTION
## Description
This PR changes the bump version GitHub Action name to trigger the GH Actions and test that bump version is disabled 