### PR TITLE
feat: add api integration test

### DIFF
--- a/eox_tenant/test/tutor/integration_test_tutor.py
+++ b/eox_tenant/test/tutor/integration_test_tutor.py
@@ -4,7 +4,7 @@ Test integration file.
 from django.test import TestCase, override_settings
 
 
-@override_settings(ALLOWED_HOSTS=['local.edly.io', 'testserver'], SITE_ID=2)
+@override_settings(ALLOWED_HOSTS=['testserver'], SITE_ID=2)
 class TutorIntegrationTestCase(TestCase):
     """
     Tests integration with openedx
@@ -36,13 +36,10 @@ class TutorIntegrationTestCase(TestCase):
         """
         info_view_url = f'{self.base_url}/eox-tenant/eox-info'
 
-        # Simulate a GET request to the info endpoint using the full URL
         response = self.client.get(info_view_url)
 
-        # Verify the response status code
         self.assertEqual(response.status_code, 200)
 
-        # Verify the response format
         response_data = response.json()
         self.assertIn('version', response_data)
         self.assertIn('name', response_data)

--- a/eox_tenant/test/tutor/integration_test_tutor.py
+++ b/eox_tenant/test/tutor/integration_test_tutor.py
@@ -1,13 +1,20 @@
 """
 Test integration file.
 """
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 
+@override_settings(ALLOWED_HOSTS=['local.edly.io', 'testserver'], SITE_ID=2)
 class TutorIntegrationTestCase(TestCase):
     """
     Tests integration with openedx
     """
+
+    def setUp(self):
+        """
+        Set up the base URL for the tests
+        """
+        self.base_url = 'http://local.edly.io'
 
     # pylint: disable=import-outside-toplevel,unused-import
     def test_current_settings_code_imports(self):
@@ -22,3 +29,21 @@ class TutorIntegrationTestCase(TestCase):
         import eox_tenant.edxapp_wrapper.backends.bearer_authentication_l_v1  # isort:skip
         import eox_tenant.edxapp_wrapper.backends.edxmako_l_v1  # isort:skip
         import eox_tenant.edxapp_wrapper.backends.edx_auth_n_v1  # isort:skip
+
+    def test_info_view(self):
+        """
+        Tests the info view endpoint in Tutor
+        """
+        info_view_url = f'{self.base_url}/eox-tenant/eox-info'
+
+        # Simulate a GET request to the info endpoint using the full URL
+        response = self.client.get(info_view_url)
+
+        # Verify the response status code
+        self.assertEqual(response.status_code, 200)
+
+        # Verify the response format
+        response_data = response.json()
+        self.assertIn('version', response_data)
+        self.assertIn('name', response_data)
+        self.assertIn('git', response_data)


### PR DESCRIPTION
## Description
This PR adds validation for the /eox-tenant/eox-info endpoint in the integration test

## How to test
Checks:

- Integration / integration-test (<17.0.0) (pull_request)

- Integration / integration-test (<18.0.0) (pull_request)

## Other information

SITE_ID = 2 is used to fix the error: django.contrib.sites.models.Site.DoesNotExist: Site match query does not exist.

When running an instance, SITE_ID is 2, so the setting was overridden so that during testing it also takes the SITE_ID = 2

https://edunext.atlassian.net/browse/DS-993