### PR TITLE
chore: assign @eduNEXT/heimdall as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # The following team is maintainer of this repo
-* @eduNEXT/dedalo
+* @eduNEXT/heimdall


### PR DESCRIPTION
This PR updates the CODEOWNERS file to assign maintenance responsibilities to @eduNEXT/heimdall.