### PR TITLE
feat: add `update-by-domain` Action and Enforce JSON Field Validations in TenantConfig API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v13.1.0](https://github.com/eduNEXT/eox-tenant/compare/v13.0.0...v13.1.0) - (2025-02-27)
+
+### Features
+- **API:** Added `update-by-domain` action in `TenantConfigViewSet` to allow updates using `route__domain` as a lookup field. This enhances flexibility for scenarios where only the domain is known.
+
+### Improvements
+- **Validation:** Enforced dictionary validation for `lms_configs`, `studio_configs`, `theming_configs`, and `meta` fields in `TenantConfigSerializer`. These fields now strictly accept only dictionary values, preventing unexpected data types.
+
 ## [v13.0.0](https://github.com/eduNEXT/eox-tenant/compare/v12.1.0...v13.0.0) - (2025-01-20)
 
 #### Features

--- a/eox_tenant/__init__.py
+++ b/eox_tenant/__init__.py
@@ -1,4 +1,4 @@
 """
 Init for eox-tenant.
 """
-__version__ = '13.0.0'
+__version__ = '13.1.0'

--- a/eox_tenant/api/v1/serializers.py
+++ b/eox_tenant/api/v1/serializers.py
@@ -32,6 +32,30 @@ class TenantConfigSerializer(serializers.ModelSerializer):
         model = TenantConfig
         fields = '__all__'
 
+    def validate_lms_configs(self, value):
+        """Ensure lms_configs is a dictionary."""
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("lms_configs must be a dictionary.")
+        return value
+
+    def validate_studio_configs(self, value):
+        """Ensure studio_configs is a dictionary."""
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("studio_configs must be a dictionary.")
+        return value
+
+    def validate_theming_configs(self, value):
+        """Ensure theming_configs is a dictionary."""
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("theming_configs must be a dictionary.")
+        return value
+
+    def validate_meta(self, value):
+        """Ensure meta is a dictionary."""
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("meta must be a dictionary.")
+        return value
+
 
 class RouteSerializer(serializers.ModelSerializer):
     """Serializer class for Route model."""

--- a/eox_tenant/api/v1/tests/test_tenant_config.py
+++ b/eox_tenant/api/v1/tests/test_tenant_config.py
@@ -7,10 +7,10 @@ from mock import patch
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
-from eox_tenant.models import TenantConfig
+from eox_tenant.models import Route, TenantConfig
 
 
-class TenantConfigAPITest(APITestCase):
+class TenantConfigAPITest(APITestCase):  # pylint: disable=too-many-instance-attributes
     """TenantConfig API TestCase."""
 
     patch_permissions = patch('eox_tenant.api.v1.permissions.EoxTenantAPIPermission.has_permission', return_value=True)
@@ -31,6 +31,16 @@ class TenantConfigAPITest(APITestCase):
             theming_configs={'key': 'value'},
             meta={'key': 'value'},
         )
+        self.tenant_config_with_route = TenantConfig.objects.create(
+            external_key='test_key_with_route',
+            lms_configs={'PLATFORM_NAME': 'Old Name'},
+            studio_configs={'key': 'value'},
+            theming_configs={'key': 'value'},
+            meta={'key': 'value'},
+        )
+        self.domain = 'site3.localhost'
+        self.route = Route.objects.create(domain=self.domain, config=self.tenant_config_with_route)
+        self.update_by_domain_url = f'{self.url}update-by-domain/'
         self.url_detail = f'{self.url}{self.tenant_config_example.pk}/'
 
     @patch_permissions
@@ -50,8 +60,10 @@ class TenantConfigAPITest(APITestCase):
     @patch_permissions
     def test_create_tenant_config(self, _):
         """Must create new TenantConfig."""
+        tenant_config_objects_count = TenantConfig.objects.count()
+        external_key = 'test_key_3'
         data = {
-            'external_key': 'test_key',
+            'external_key': external_key,
             'lms_configs': {'key': 'value'},
             'studio_configs': {'key': 'value'},
             'theming_configs': {'key': 'value'},
@@ -61,12 +73,11 @@ class TenantConfigAPITest(APITestCase):
         response = self.client.post(self.url, data=data, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-        self.assertEqual(TenantConfig.objects.count(), 2)
-        self.assertEqual(TenantConfig.objects.get(pk=2).external_key, 'test_key')
-        self.assertEqual(TenantConfig.objects.get(pk=2).lms_configs, {'key': 'value'})
-        self.assertEqual(TenantConfig.objects.get(pk=2).studio_configs, {'key': 'value'})
-        self.assertEqual(TenantConfig.objects.get(pk=2).theming_configs, {'key': 'value'})
-        self.assertEqual(TenantConfig.objects.get(pk=2).meta, {'key': 'value'})
+        self.assertEqual(TenantConfig.objects.count(), tenant_config_objects_count + 1)
+        self.assertEqual(TenantConfig.objects.get(external_key=external_key).lms_configs, {'key': 'value'})
+        self.assertEqual(TenantConfig.objects.get(external_key=external_key).studio_configs, {'key': 'value'})
+        self.assertEqual(TenantConfig.objects.get(external_key=external_key).theming_configs, {'key': 'value'})
+        self.assertEqual(TenantConfig.objects.get(external_key=external_key).meta, {'key': 'value'})
 
     @patch_permissions
     def test_post_input_empty_data(self, _):
@@ -134,3 +145,102 @@ class TenantConfigAPITest(APITestCase):
         response = self.client.delete(self.url_detail)
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    @patch_permissions
+    def test_update_tenant_config_by_domain_success(self, _):
+        """Must successfully update a TenantConfig using `route__domain`."""
+        data = {
+            "lms_configs": {
+                "PLATFORM_NAME": "Updated Name"
+            }
+        }
+        response = self.client.patch(f"{self.update_by_domain_url}?domain={self.domain}", data=data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["lms_configs"]["PLATFORM_NAME"], "Updated Name")
+
+    @patch_permissions
+    def test_update_tenant_config_by_domain_missing_query_param(self, _):
+        """Must return 400 when domain query parameter is missing."""
+        data = {
+            "lms_configs": {
+                "PLATFORM_NAME": "Updated Name"
+            }
+        }
+        response = self.client.patch(self.update_by_domain_url, data=data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error"], "The 'domain' query parameter is required.")
+
+    @patch_permissions
+    def test_update_tenant_config_by_domain_not_found(self, _):
+        """Must return 404 when no TenantConfig is found for the given domain."""
+        data = {
+            "lms_configs": {
+                "PLATFORM_NAME": "Updated Name"
+            }
+        }
+        response = self.client.patch(f"{self.update_by_domain_url}?domain=unknown.localhost", data=data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["error"], "No TenantConfig found for domain 'unknown.localhost'.")
+
+    @patch_permissions
+    def test_update_tenant_config_by_domain_empty_payload(self, _):
+        """Must ensure that if an empty payload is sent, nothing gets changed."""
+        external_key = self.tenant_config_with_route.external_key
+        lms_configs = self.tenant_config_with_route.lms_configs
+        studio_configs = self.tenant_config_with_route.studio_configs
+        theming_configs = self.tenant_config_with_route.theming_configs
+        meta = self.tenant_config_with_route.meta
+
+        response = self.client.patch(f"{self.update_by_domain_url}?domain={self.domain}", data={}, format='json')
+        self.tenant_config_with_route.refresh_from_db()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self.tenant_config_with_route.external_key, external_key)
+        self.assertEqual(self.tenant_config_with_route.lms_configs, lms_configs)
+        self.assertEqual(self.tenant_config_with_route.studio_configs, studio_configs)
+        self.assertEqual(self.tenant_config_with_route.theming_configs, theming_configs)
+        self.assertEqual(self.tenant_config_with_route.meta, meta)
+
+    @patch_permissions
+    def test_update_tenant_config_by_domain_invalid_data(self, _):
+        """Must return 400 when the payload contains invalid data."""
+        data = {
+            "lms_configs": "Invalid structure"  # Should be a dictionary
+        }
+        response = self.client.patch(f"{self.update_by_domain_url}?domain={self.domain}", data=data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch_permissions
+    def test_partial_update_tenant_config_by_domain(self, _):
+        """Must allow partial updates without modifying other fields."""
+        data = {
+            "lms_configs": {
+                "PLATFORM_NAME": "New Partial Update"
+            }
+        }
+        response = self.client.patch(f"{self.update_by_domain_url}?domain={self.domain}", data=data, format='json')
+        print(100 * "#")
+        print(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.tenant_config_with_route.refresh_from_db()
+        self.assertEqual(self.tenant_config_with_route.lms_configs["PLATFORM_NAME"], "New Partial Update")
+
+    @patch_permissions
+    def test_update_tenant_config_by_domain_preserves_other_fields(self, _):
+        """Ensure updating one field does not erase other fields."""
+        data = {
+            "lms_configs": {
+                "PLATFORM_NAME": "Updated Platform Name"
+            }
+        }
+        response = self.client.patch(f"{self.update_by_domain_url}?domain={self.domain}", data=data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.tenant_config_with_route.refresh_from_db()
+        self.assertEqual(self.tenant_config_with_route.lms_configs["PLATFORM_NAME"], "Updated Platform Name")
+        self.assertEqual(self.tenant_config_with_route.studio_configs, {"key": "value"})

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 13.0.0
+current_version = 13.1.0
 commit = False
 tag = False
 


### PR DESCRIPTION
#### **Summary**
This PR introduces two key improvements to the `TenantConfigViewSet`:
1. **New `update-by-domain` action**: Allows updating a `TenantConfig` by searching for it using its domain `route__domain`, rather than the default lookup fields (`id` or `external_key`).
2. **Stronger JSON field validation in `TenantConfigSerializer`**: Ensures that the `lms_configs`, `studio_configs`, `theming_configs`, and `meta` fields must always be dictionaries.

### **Motivation**
#### **Why Add `update-by-domain` action?**
In Control Center, an automated process is required to **create new subscriptions** and correctly link them to their respective Open edX sites. To achieve this, Control Center must be able to **update the `external_key` of the site (TenantConfig)** so that it matches the `external_key` assigned to the tenant in Control Center.  

This alignment is crucial because Control Center relies on the `external_key` to establish connections with the Open edX site and enable the necessary functionalities for managing the site.  

However, in this process, Control Center **only has access to the site's domain (`route__domain`)**, not its `id` or `external_key`. Therefore, this new `update-by-domain` action allows Control Center to **update the TenantConfig using the domain as the lookup field**, ensuring that the correct site is modified while maintaining compatibility with existing API consumers.  

#### **Why Strengthen JSON Field Validation?**
The existing serializer used `serializers.JSONField()` for storing configurations (`lms_configs`, `studio_configs`, `theming_configs`, and `meta`). However, DRF’s `JSONField` does **not** enforce any specific type, meaning these fields could accept **any valid JSON value** (e.g., strings, numbers, lists). This led to unexpected behavior where incorrect data types were stored without validation.

To address this, **custom field validators** were added to enforce that these fields must always be **dictionaries**. This ensures data integrity and prevents errors caused by unexpected input types.

---

### **Changes Introduced**
#### **`update-by-domain` Action**
- A `PATCH` request can now be made to:
  ```
  PATCH /eox-tenant/api/v1/configs/update-by-domain/?domain=<domain>
  ```
- If a `TenantConfig` is found using `route__domain`, it is updated and returned.
- If no `TenantConfig` is found, a `404 Not Found` response is returned.
- If the `domain` query parameter is missing, a `400 Bad Request` response is returned.

### **How to Test**
#### **Update a TenantConfig by its `domain`**
```http
PATCH /eox-tenant/api/v1/configs/update-by-domain/?domain=test.domain.co
Content-Type: application/json

{
    "lms_configs": {
        "PLATFORM_NAME": "Updated Name"
        .... <all the other new config values that should go here>
    }
}
```
Expected: `200 OK` with updated TenantConfig.

### **Backward Compatibility**
- The `update-by-domain` action does **not** modify existing API behavior.
- The new validations only enforce expected data structures—they **do not** affect existing valid data.
- No impact on existing clients consuming this API.