### PR TITLE
feat: add teak and remove redwood tutor versions from integration tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tutor_version: ['<18.0.0', '<19.0.0', 'main']
+        tutor_version: ['<20.0.0', '<21.0.0', 'main']
     steps:
       - name: Run Integration Tests
         uses: eduNEXT/integration-test-in-tutor@main


### PR DESCRIPTION
This PR updates the Tutor versions used in integration tests to include Tutor Teak and remove Redwood support.