### PR TITLE
fix: remove unused line in signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v14.1.2](https://github.com/eduNEXT/eox-tenant/compare/v14.1.1...v14.1.2) - (2025-09-09)
+
+### Changed
+
+- Removed unused code introduced in `tenant_context_addition` and `_start_async_tenant` that attempted to inject the `eox_tenant_sender` key directly into the Celery task `body['kwargs']`.
+
 ## [v14.1.1](https://github.com/eduNEXT/eox-tenant/compare/v14.1.0...v14.1.1) - (2025-08-21)
 
 ### Added

--- a/eox_tenant/signals.py
+++ b/eox_tenant/signals.py
@@ -232,7 +232,6 @@ def tenant_context_addition(sender, body, headers, *args, **kwargs):  # pylint: 
 
     get_host_func = AsyncTaskHandler().get_host_from_task(sender)
     headers['eox_tenant_sender'] = get_host_func(body)
-    body['kwargs']['eox_tenant_sender'] = get_host_func(body)
 
 
 def start_async_lms_tenant(sender, *args, **kwargs):  # pylint: disable=unused-argument
@@ -263,7 +262,6 @@ def _start_async_tenant(sender, config_key):
     context = sender.request
     headers = context.get('headers') or {}
     http_host = headers.get('eox_tenant_sender')
-    http_host = context.get('kwargs', {}).pop('eox_tenant_sender', http_host)
 
     if not http_host:  # Reset settings in case of no tenant.
         LOG.warning("Could not find the host information for eox_tenant.signals. ")


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy, try to fill out the template well.
-->

## Description

This PR removes unused code introduced in `tenant_context_addition` and `_start_async_tenant` that attempted to inject the `eox_tenant_sender` key directly into the Celery task `body['kwargs']`.

During debugging on Tutor TEAK with **Celery protocol v2**, we reproduced errors like:

```
TypeError: tuple indices must be integers or slices, not str
```

This happened because, under protocol v2, the `body` of a Celery message can arrive as a tuple instead of a dictionary. Trying to set `body['kwargs']['eox_tenant_sender']` was not only unsafe, but also unnecessary.

The correct and reliable way to retrieve the host information is from the **`headers`**, where `eox_tenant_sender` is already set via `tenant_context_addition`. This approach keeps the plugin compatible with **both Celery protocol v1 and v2**, since `headers` is consistent across versions.

### Changes

* Removed the line that added `eox_tenant_sender` into `body['kwargs']` in `tenant_context_addition`.
* Removed the lookup/pop of `eox_tenant_sender` from `context['kwargs']` in `_start_async_tenant`.

### Why

* The removed lines had no practical use, as the key is reliably available in `headers`.
* Prevents `TypeError` in Celery v2 where `body` may be a tuple.
* Ensures compatibility between protocol v1 and v2.

## Testing instructions

- You must use a `local` environment with this `eox-tenant` version installed.
- After that, you can go to https://{tutor_local_domain}/courses/{your-course-id}/instructor#view-data_download and try to download any report as CSV.
- Then you can check logs of LMS and there should be no mistake about `eox-tenant.signals`

## Checklist for Merge

- [ ] Tested in a remote environment
- [ ] Updated documentation
- [ ] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->