### PR TITLE
chore: bump version to 14.3.0 and document tenant context fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v14.3.0](https://github.com/eduNEXT/eox-tenant/compare/v14.2.1...v14.3.0) - (2026-03-12)
+
+### Fixed
+- Fix tenant async settings handling.
+- Support Celery task protocol v2.
+- Adjust tests and revert unused signal line removal.
+
 ## [v14.2.1](https://github.com/eduNEXT/eox-tenant/compare/v14.2.0...v14.2.1) - (2026-01-20)
 
 ### Changed

--- a/eox_tenant/__init__.py
+++ b/eox_tenant/__init__.py
@@ -1,4 +1,4 @@
 """
 Init for eox-tenant.
 """
-__version__ = '14.2.1'
+__version__ = '14.3.0'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 14.2.1
+current_version = 14.3.0
 commit = False
 tag = False
 


### PR DESCRIPTION
## Description

This PR corrects that by documenting the fix and bumping the version for the new release v14.3.0.

## Changes

- Fix tenant context handling for Celery task protocol v2.
- Bump project version to 14.3.0. 
- Add/update CHANGELOG.md with the tenant fix details.