### PR TITLE
feat: make case sensitive name org field (#262)

### DIFF
--- a/eox_tenant/migrations/0009_tenant_org_name_case_sensitive.py
+++ b/eox_tenant/migrations/0009_tenant_org_name_case_sensitive.py
@@ -1,0 +1,26 @@
+# Add collation for tenant organization name column to make it case sensitive.
+
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    db_engine = settings.DATABASES['default']['ENGINE']
+    # If the engine is SQLite, use BINARY
+    if 'sqlite' in db_engine:
+        db_collation_name = 'BINARY'
+    # Otherwise, default to MySQL's utf8mb4_bin
+    elif 'mysql' in db_engine:
+        db_collation_name = 'utf8mb4_bin'
+
+    dependencies = [
+        ('eox_tenant', '0008_synchronize_tenants'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='tenantorganization',
+            name='name',
+            field=models.CharField(db_collation=db_collation_name, db_index=True, max_length=100, unique=True),
+        ),
+    ]

--- a/eox_tenant/models.py
+++ b/eox_tenant/models.py
@@ -23,6 +23,7 @@ class TenantOrganization(models.Model):
         max_length=100,
         unique=True,
         db_index=True,
+        db_collation="utf8mb4_bin",
     )
 
     class Meta:


### PR DESCRIPTION
## Description

### The Problem
In Open edX, the `SiteConfiguration` model is monkey-patched or tenant proxied by `eox-tenant` to manage data on a tenant-by-tenant basis. As part of this, the [`has_org(org)`](https://github.com/openedx/openedx-platform/blob/30269ea08f92b13534d48a59c0effc71f811ac68/openedx/core/djangoapps/site_configuration/models.py#L140) method—which determines if a site is associated with a specific organization—is not overridden by the `tenant_wise` proxy to check against the organizations stored in `eox_tenant`'s `TenantOrganizations`, but the `get_all_orgs()` method yes.

In  the original `get_all_courses` of OpenEdX which  returns both results in the `course_org_filter`.
https://github.com/openedx/openedx-platform/blob/30269ea08f92b13534d48a59c0effc71f811ac68/openedx/core/djangoapps/site_configuration/models.py#L115C9-L130

<img width="1891" height="475" alt="image" src="https://github.com/user-attachments/assets/393a8af4-1bfc-4c55-8221-ae81e3734ee1" />

However, this override introduced a strict **case-sensitivity issue**. If the `org` parameter passed to `has_org()` is in **lowercase**, but the corresponding `TenantOrganization` was originally created in **uppercase** (or vice versa), the match fails and the method incorrectly returns `False`. Because `get_all_orgs()` is overridden by tenant-wise loading only the organization once in its original casing, any course created with an alternate casing would not be recognized, resulting in the tenant failing to load those courses. 

https://github.com/eduNEXT/eox-tenant/blob/aca527b44e9a089dfa211548062b23713fa8efd7/eox_tenant/tenant_wise/proxies.py#L109-L124

Because due the casing in TenantOrganization the `course_org_filter ` the tenantConfig only created one TenantOrganization, in this case the Uppercase, but the lower not.

<img width="1240" height="656" alt="2026-06-24_16-59" src="https://github.com/user-attachments/assets/da8c4683-11a9-4645-be4c-d58f3f269ea2" />

<img width="1783" height="833" alt="image" src="https://github.com/user-attachments/assets/da8513a9-4b01-4126-bc4b-6ded608b60a2" />


### The Solution
This PR resolves the case-sensitivity mismatch by ensuring that both the lowercase and uppercase variations of the organization are handled and created. Instead of relying on a single, strictly-cased organization record, multiple casing formats are supported. This guarantees that `has_org()` successfully resolves the organization check regardless of the casing the user uses during course creation. 

## Test
1. Run migrations.
2. Create a `TenantOrganization` with an uppercase name (e.g., `MYORG`).

Validate the get_or_create method of the ORM allows to create  `TenantOrganization` based on the case of the `name` column.

## Before 

<img width="1436" height="393" alt="2026-06-22_18-44" src="https://github.com/user-attachments/assets/f7efcc54-e5f1-4288-a292-6e9740a153ae" />

<img width="1585" height="506" alt="2026-06-22_18-40" src="https://github.com/user-attachments/assets/7368a4e5-0de4-47b4-9655-9ee7f334fc6e" />

## After
<img width="937" height="212" alt="2026-06-22_18-46" src="https://github.com/user-attachments/assets/cc901403-0bcf-4858-ad23-6c2c4ce2dd9e" />

<img width="1477" height="492" alt="2026-06-22_18-41" src="https://github.com/user-attachments/assets/c5a22fd2-f7da-4650-9574-72251a06fd12" />